### PR TITLE
Fix HTML injection

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -37,6 +37,15 @@ const Utils = {
       clearTimeout(timeout);
       timeout = setTimeout(() => func(...args), wait);
     };
+  },
+  escapeHTML(str) {
+    if (typeof str !== 'string') return str;
+    return str
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
   }
 };
 
@@ -124,11 +133,11 @@ async function carregarRecadosRecentes(limit = 10) {
       <tr>
         <td>
           <div style="font-weight:500;">${Utils.formatDate(recado.data_ligacao)}</div>
-          <div style="font-size:0.75rem;color:var(--text-secondary);">${recado.hora_ligacao}</div>
+          <div style="font-size:0.75rem;color:var(--text-secondary);">${Utils.escapeHTML(recado.hora_ligacao)}</div>
         </td>
-        <td style="font-weight:500;">${recado.destinatario}</td>
-        <td>${recado.remetente_nome}</td>
-        <td>${Utils.truncateText(recado.assunto, 40)}</td>
+        <td style="font-weight:500;">${Utils.escapeHTML(recado.destinatario)}</td>
+        <td>${Utils.escapeHTML(recado.remetente_nome)}</td>
+        <td>${Utils.escapeHTML(Utils.truncateText(recado.assunto, 40))}</td>
         <td>
           <span class="badge badge-${recado.situacao.replace('_','')}">
             ${getSituacaoLabel(recado.situacao)}

--- a/public/js/recados.js
+++ b/public/js/recados.js
@@ -102,41 +102,101 @@ async function carregarRecados(page = 1) {
  */
 function renderizarRecados(recados) {
   const container = document.getElementById('listaRecados');
+  container.innerHTML = '';
   if (!recados.length) {
     container.innerHTML = `<div style="text-align:center;padding:2rem;color:var(--text-secondary);">📝 Nenhum recado encontrado</div>`;
     return;
   }
-  const rows = recados.map(r => `
-    <tr>
-      <td>
-        <div style="font-weight:500;">${Utils.formatDate(r.data_ligacao)}</div>
-        <div style="font-size:0.75rem;color:var(--text-secondary);">${r.hora_ligacao}</div>
-      </td>
-      <td style="font-weight:500;">${r.destinatario}</td>
-      <td>
-        <div>${r.remetente_nome}</div>
-        ${r.remetente_telefone ? `<div style="font-size:0.75rem;color:var(--text-secondary);">${r.remetente_telefone}</div>` : ''}
-      </td>
-      <td>${Utils.truncateText(r.assunto,50)}</td>
-      <td><span class="badge badge-${r.situacao.replace('_','')}">${getSituacaoLabel(r.situacao)}</span></td>
-      <td>
-        <div style="display:flex;gap:0.5rem;">
-          <a href="/visualizar-recado/${r.id}" class="btn btn-outline btn-sm">👁️</a>
-          <a href="/editar-recado/${r.id}" class="btn btn-outline btn-sm">✏️</a>
-          <button class="btn btn-error btn-sm" onclick="excluirRecado(${r.id})">🗑️</button>
-        </div>
-      </td>
-    </tr>`).join('');
 
-  container.innerHTML = `
-    <div class="table-container">
-      <table class="table">
-        <thead>
-          <tr><th>Data/Hora</th><th>Destinatário</th><th>Remetente</th><th>Assunto</th><th>Situação</th><th>Ações</th></tr>
-        </thead>
-        <tbody>${rows}</tbody>
-      </table>
-    </div>`;
+  const wrapper = document.createElement('div');
+  wrapper.className = 'table-container';
+  const table = document.createElement('table');
+  table.className = 'table';
+  const thead = document.createElement('thead');
+  const headerRow = document.createElement('tr');
+  ['Data/Hora', 'Destinatário', 'Remetente', 'Assunto', 'Situação', 'Ações'].forEach(text => {
+    const th = document.createElement('th');
+    th.textContent = text;
+    headerRow.appendChild(th);
+  });
+  thead.appendChild(headerRow);
+  const tbody = document.createElement('tbody');
+
+  recados.forEach(r => {
+    const tr = document.createElement('tr');
+
+    const tdData = document.createElement('td');
+    const dateDiv = document.createElement('div');
+    dateDiv.style.fontWeight = '500';
+    dateDiv.textContent = Utils.formatDate(r.data_ligacao);
+    const timeDiv = document.createElement('div');
+    timeDiv.style.fontSize = '0.75rem';
+    timeDiv.style.color = 'var(--text-secondary)';
+    timeDiv.textContent = r.hora_ligacao;
+    tdData.appendChild(dateDiv);
+    tdData.appendChild(timeDiv);
+    tr.appendChild(tdData);
+
+    const tdDest = document.createElement('td');
+    tdDest.style.fontWeight = '500';
+    tdDest.textContent = r.destinatario;
+    tr.appendChild(tdDest);
+
+    const tdRem = document.createElement('td');
+    const nomeDiv = document.createElement('div');
+    nomeDiv.textContent = r.remetente_nome;
+    tdRem.appendChild(nomeDiv);
+    if (r.remetente_telefone) {
+      const telDiv = document.createElement('div');
+      telDiv.style.fontSize = '0.75rem';
+      telDiv.style.color = 'var(--text-secondary)';
+      telDiv.textContent = r.remetente_telefone;
+      tdRem.appendChild(telDiv);
+    }
+    tr.appendChild(tdRem);
+
+    const tdAssunto = document.createElement('td');
+    tdAssunto.textContent = Utils.truncateText(r.assunto, 50);
+    tr.appendChild(tdAssunto);
+
+    const tdSit = document.createElement('td');
+    const span = document.createElement('span');
+    span.className = `badge badge-${r.situacao.replace('_','')}`;
+    span.textContent = getSituacaoLabel(r.situacao);
+    tdSit.appendChild(span);
+    tr.appendChild(tdSit);
+
+    const tdAcoes = document.createElement('td');
+    const actionDiv = document.createElement('div');
+    actionDiv.style.display = 'flex';
+    actionDiv.style.gap = '0.5rem';
+
+    const viewLink = document.createElement('a');
+    viewLink.href = `/visualizar-recado/${r.id}`;
+    viewLink.className = 'btn btn-outline btn-sm';
+    viewLink.textContent = '👁️';
+    const editLink = document.createElement('a');
+    editLink.href = `/editar-recado/${r.id}`;
+    editLink.className = 'btn btn-outline btn-sm';
+    editLink.textContent = '✏️';
+    const delBtn = document.createElement('button');
+    delBtn.className = 'btn btn-error btn-sm';
+    delBtn.textContent = '🗑️';
+    delBtn.addEventListener('click', () => excluirRecado(r.id));
+
+    actionDiv.appendChild(viewLink);
+    actionDiv.appendChild(editLink);
+    actionDiv.appendChild(delBtn);
+    tdAcoes.appendChild(actionDiv);
+    tr.appendChild(tdAcoes);
+
+    tbody.appendChild(tr);
+  });
+
+  table.appendChild(thead);
+  table.appendChild(tbody);
+  wrapper.appendChild(table);
+  container.appendChild(wrapper);
 }
 
 /**

--- a/views/relatorios.ejs
+++ b/views/relatorios.ejs
@@ -68,13 +68,24 @@
         const tbody = document.getElementById('relPorDestinatario');
         porDest.forEach(r => {
           const tr = document.createElement('tr');
-          tr.innerHTML = `
-            <td>${r.destinatario}</td>
-            <td>${r.total}</td>
-            <td>${r.pendente}</td>
-            <td>${r.em_andamento}</td>
-            <td>${r.resolvido}</td>
-          `;
+
+          const destTd = document.createElement('td');
+          destTd.textContent = r.destinatario;
+          const totalTd = document.createElement('td');
+          totalTd.textContent = r.total;
+          const pendTd = document.createElement('td');
+          pendTd.textContent = r.pendente;
+          const andTd = document.createElement('td');
+          andTd.textContent = r.em_andamento;
+          const resTd = document.createElement('td');
+          resTd.textContent = r.resolvido;
+
+          tr.appendChild(destTd);
+          tr.appendChild(totalTd);
+          tr.appendChild(pendTd);
+          tr.appendChild(andTd);
+          tr.appendChild(resTd);
+
           tbody.appendChild(tr);
         });
       } catch (e) {

--- a/views/relatorios.html
+++ b/views/relatorios.html
@@ -77,13 +77,24 @@
         const tbody = document.getElementById('relPorDestinatario');
         porDest.forEach(r => {
           const tr = document.createElement('tr');
-          tr.innerHTML = `
-            <td>${r.destinatario}</td>
-            <td>${r.total}</td>
-            <td>${r.pendente}</td>
-            <td>${r.em_andamento}</td>
-            <td>${r.resolvido}</td>
-          `;
+
+          const destTd = document.createElement('td');
+          destTd.textContent = r.destinatario;
+          const totalTd = document.createElement('td');
+          totalTd.textContent = r.total;
+          const pendTd = document.createElement('td');
+          pendTd.textContent = r.pendente;
+          const andTd = document.createElement('td');
+          andTd.textContent = r.em_andamento;
+          const resTd = document.createElement('td');
+          resTd.textContent = r.resolvido;
+
+          tr.appendChild(destTd);
+          tr.appendChild(totalTd);
+          tr.appendChild(pendTd);
+          tr.appendChild(andTd);
+          tr.appendChild(resTd);
+
           tbody.appendChild(tr);
         });
       } catch (e) {

--- a/views/visualizar-recado.ejs
+++ b/views/visualizar-recado.ejs
@@ -26,25 +26,47 @@
   <script>
     document.addEventListener('DOMContentLoaded', async () => {
       const id = location.pathname.split('/').pop();
+      const container = document.getElementById('detalhesRecado');
       try {
         const { data: recado } = await API.getRecado(id);
-        document.getElementById('detalhesRecado').innerHTML = `
-          <p><strong>Data/Hora:</strong> ${recado.data_ligacao} ${recado.hora_ligacao}</p>
-          <p><strong>Destinatário:</strong> ${recado.destinatario}</p>
-          <p><strong>Remetente:</strong> ${recado.remetente_nome}</p>
-          <p><strong>Telefone:</strong> ${recado.remetente_telefone || '-'}</p>
-          <p><strong>E-mail:</strong> ${recado.remetente_email || '-'}</p>
-          <p><strong>Horário de Retorno:</strong> ${recado.horario_retorno || '-'}</p>
-          <p><strong>Assunto:</strong> ${recado.assunto}</p>
-          <p><strong>Situação:</strong> ${recado.situacao}</p>
-          <p><strong>Observações:</strong> ${recado.observacoes || '-'}</p>
-          <div style="margin-top:1rem;">
-            <a href="/editar-recado/${id}" class="btn btn-primary">✏️ Editar</a>
-            <a href="/recados" class="btn btn-outline">Voltar</a>
-          </div>
-        `;
+        container.textContent = '';
+
+        const dados = [
+          ['Data/Hora:', `${recado.data_ligacao} ${recado.hora_ligacao}`],
+          ['Destinatário:', recado.destinatario],
+          ['Remetente:', recado.remetente_nome],
+          ['Telefone:', recado.remetente_telefone || '-'],
+          ['E-mail:', recado.remetente_email || '-'],
+          ['Horário de Retorno:', recado.horario_retorno || '-'],
+          ['Assunto:', recado.assunto],
+          ['Situação:', recado.situacao],
+          ['Observações:', recado.observacoes || '-']
+        ];
+
+        dados.forEach(([label, value]) => {
+          const p = document.createElement('p');
+          const strong = document.createElement('strong');
+          strong.textContent = label + ' ';
+          p.appendChild(strong);
+          p.append(document.createTextNode(value));
+          container.appendChild(p);
+        });
+
+        const actions = document.createElement('div');
+        actions.style.marginTop = '1rem';
+        const edit = document.createElement('a');
+        edit.href = `/editar-recado/${id}`;
+        edit.className = 'btn btn-primary';
+        edit.textContent = '✏️ Editar';
+        const back = document.createElement('a');
+        back.href = '/recados';
+        back.className = 'btn btn-outline';
+        back.textContent = 'Voltar';
+        actions.appendChild(edit);
+        actions.appendChild(back);
+        container.appendChild(actions);
       } catch (e) {
-        document.getElementById('detalhesRecado').textContent = 'Erro ao carregar recado.';
+        container.textContent = 'Erro ao carregar recado.';
       }
     });
   </script>

--- a/views/visualizar-recado.html
+++ b/views/visualizar-recado.html
@@ -35,25 +35,47 @@
   <script>
     document.addEventListener('DOMContentLoaded', async () => {
       const id = location.pathname.split('/').pop();
+      const container = document.getElementById('detalhesRecado');
       try {
         const { data: recado } = await API.getRecado(id);
-        document.getElementById('detalhesRecado').innerHTML = `
-          <p><strong>Data/Hora:</strong> ${recado.data_ligacao} ${recado.hora_ligacao}</p>
-          <p><strong>Destinatário:</strong> ${recado.destinatario}</p>
-          <p><strong>Remetente:</strong> ${recado.remetente_nome}</p>
-          <p><strong>Telefone:</strong> ${recado.remetente_telefone || '-'}</p>
-          <p><strong>E-mail:</strong> ${recado.remetente_email || '-'}</p>
-          <p><strong>Horário de Retorno:</strong> ${recado.horario_retorno || '-'}</p>
-          <p><strong>Assunto:</strong> ${recado.assunto}</p>
-          <p><strong>Situação:</strong> ${recado.situacao}</p>
-          <p><strong>Observações:</strong> ${recado.observacoes || '-'}</p>
-          <div style="margin-top:1rem;">
-            <a href="/editar-recado/${id}" class="btn btn-primary">✏️ Editar</a>
-            <a href="/recados" class="btn btn-outline">Voltar</a>
-          </div>
-        `;
+        container.textContent = '';
+
+        const dados = [
+          ['Data/Hora:', `${recado.data_ligacao} ${recado.hora_ligacao}`],
+          ['Destinatário:', recado.destinatario],
+          ['Remetente:', recado.remetente_nome],
+          ['Telefone:', recado.remetente_telefone || '-'],
+          ['E-mail:', recado.remetente_email || '-'],
+          ['Horário de Retorno:', recado.horario_retorno || '-'],
+          ['Assunto:', recado.assunto],
+          ['Situação:', recado.situacao],
+          ['Observações:', recado.observacoes || '-']
+        ];
+
+        dados.forEach(([label, value]) => {
+          const p = document.createElement('p');
+          const strong = document.createElement('strong');
+          strong.textContent = label + ' ';
+          p.appendChild(strong);
+          p.append(document.createTextNode(value));
+          container.appendChild(p);
+        });
+
+        const actions = document.createElement('div');
+        actions.style.marginTop = '1rem';
+        const edit = document.createElement('a');
+        edit.href = `/editar-recado/${id}`;
+        edit.className = 'btn btn-primary';
+        edit.textContent = '✏️ Editar';
+        const back = document.createElement('a');
+        back.href = '/recados';
+        back.className = 'btn btn-outline';
+        back.textContent = 'Voltar';
+        actions.appendChild(edit);
+        actions.appendChild(back);
+        container.appendChild(actions);
       } catch (e) {
-        document.getElementById('detalhesRecado').textContent = 'Erro ao carregar recado.';
+        container.textContent = 'Erro ao carregar recado.';
       }
     });
   </script>


### PR DESCRIPTION
## Summary
- sanitize HTML rendering in dashboard and recados list
- render recado details and reports using text nodes
- add `escapeHTML` utility

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687eb61e1fec832486af0005a903a5ba