### PR TITLE
Remove stray closing header tag

### DIFF
--- a/views/novo-recado.ejs
+++ b/views/novo-recado.ejs
@@ -8,7 +8,6 @@
 </head>
 <body>
     <%- include('partials/header') %>
-    </header>
 
     <main class="main">
         <div class="container">


### PR DESCRIPTION
## Summary
- remove extraneous `</header>` from `views/novo-recado.ejs`
- verify other templates for stray tags

## Testing
- `npm test` (fails: Error: no test specified)

------
https://chatgpt.com/codex/tasks/task_e_687ebb75e200832494c6e11f7b3e3e83