### PR TITLE
Secure CORS whitelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ late/
 git clone <repo>
 cd late
 npm install
+# Defina os domínios permitidos no CORS
+export ALLOWED_ORIGINS=http://localhost:3000,http://localhost:8080
 npm start
 Acesse: http://localhost:3000 ou http://<SEU-IP>:3000
 

--- a/config/cors.js
+++ b/config/cors.js
@@ -1,0 +1,11 @@
+const defaultOrigins = [
+  'http://localhost:3000',
+  'http://localhost:8080',
+  'https://seu-dominio.com'
+];
+
+const allowedOrigins = process.env.ALLOWED_ORIGINS
+  ? process.env.ALLOWED_ORIGINS.split(',').map(o => o.trim()).filter(Boolean)
+  : defaultOrigins;
+
+module.exports = { allowedOrigins };

--- a/middleware/cors.js
+++ b/middleware/cors.js
@@ -1,27 +1,16 @@
 const cors = require('cors');
+const { allowedOrigins } = require('../config/cors');
 
 const corsOptions = {
     origin: function (origin, callback) {
         // Permitir requisições sem origin (mobile apps, Postman, etc.)
         if (!origin) return callback(null, true);
-        
-        // Permitir qualquer origin em desenvolvimento
-        if (process.env.NODE_ENV !== 'production') {
+
+        if (allowedOrigins.includes(origin)) {
             return callback(null, true);
         }
-        
-        // Em produção, você pode especificar domínios específicos
-        const allowedOrigins = [
-            'http://localhost:3000',
-            'http://localhost:8080',
-            'https://seu-dominio.com'
-        ];
-        
-        if (allowedOrigins.indexOf(origin) !== -1) {
-            callback(null, true);
-        } else {
-            callback(new Error('Não permitido pelo CORS'));
-        }
+
+        callback(new Error('Não permitido pelo CORS'));
     },
     credentials: true,
     methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],

--- a/resultados_testes.md
+++ b/resultados_testes.md
@@ -16,7 +16,7 @@
 - **Express.js**: Servidor iniciando na porta 3000
 - **Estrutura de Rotas**: APIs e páginas web configuradas
 - **Banco SQLite**: Criação automática do banco e tabelas
-- **CORS**: Configurado para permitir requisições
+- **CORS**: Domínios liberados via variável `ALLOWED_ORIGINS`
 
 ### ⚠️ Problemas Identificados
 


### PR DESCRIPTION
## Summary
- pull allowed origins from `config/cors.js`
- document `ALLOWED_ORIGINS` environment variable
- note new config in test results

## Testing
- `npm install`
- `npm test` *(fails: Preset undefined not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ec39fbf088324a302695da27ccb6e