### PR TITLE
Handle recados load errors

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,5 @@
 module.exports = {
-  // Se só JS, use preset 'default'; para TS, use 'ts-jest'
-  preset: 'undefined',
+  // Para projetos em JS puro, nenhum preset é necessário
   testEnvironment: 'node',
   testMatch: ['**/__tests__/**/*.[jt]s?(x)', '**/?(*.)+(spec|test).[jt]s?(x)'],
   collectCoverage: true,

--- a/public/js/recados.js
+++ b/public/js/recados.js
@@ -94,6 +94,7 @@ async function carregarRecados(page = 1) {
   } catch (err) {
     console.error('Erro ao carregar recados:', err);
     container.innerHTML = `<div style="text-align:center;padding:2rem;color:var(--error);">❌ Erro ao carregar recados</div>`;
+    atualizarTotalResultados(0);
   }
 }
 


### PR DESCRIPTION
## Summary
- show 0 results when recados fail to load
- fix jest config so it no longer uses an invalid preset

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_687ec7670bf0832488b229c90e2d9459