### PR TITLE
Add alias itemsPorPagina for backward compat

### DIFF
--- a/public/js/recados.js
+++ b/public/js/recados.js
@@ -3,6 +3,8 @@
 let currentPage = 1;
 let currentFilters = {};
 const itemsPerPagina = 20;
+// compatibilidade com versões antigas
+const itemsPorPagina = itemsPerPagina;
 
 // Fallback para Toast.error
 if (typeof window.Toast !== 'object') {


### PR DESCRIPTION
## Summary
- add `itemsPorPagina` alias in recados.js for backwards compatibility

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_687ed8ead28483248f4a976c0b65c535