### PR TITLE
Fix CORS config for production origin

### DIFF
--- a/config/cors.js
+++ b/config/cors.js
@@ -1,7 +1,8 @@
 const defaultOrigins = [
   'http://localhost:3000',
   'http://localhost:8080',
-  'https://seu-dominio.com'
+  'https://seu-dominio.com',
+  'https://late.miahchat.com'
 ];
 
 const allowedOrigins = process.env.ALLOWED_ORIGINS

--- a/middleware/cors.js
+++ b/middleware/cors.js
@@ -10,7 +10,9 @@ const corsOptions = {
             return callback(null, true);
         }
 
-        callback(new Error('Não permitido pelo CORS'));
+        const err = new Error('Não permitido pelo CORS');
+        err.status = 403;
+        callback(err);
     },
     credentials: true,
     methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],


### PR DESCRIPTION
## Summary
- allow the production site `https://late.miahchat.com` in the default CORS origins
- mark CORS errors with HTTP status 403 so they return a proper response

## Testing
- `npx jest --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_687ef267452883248562008d1135193a