### PR TITLE
Improve cache headers

### DIFF
--- a/server.js
+++ b/server.js
@@ -56,7 +56,12 @@ app.use(express.urlencoded({ extended: true, limit: '10mb' }));
 // Cache-control
 app.use((req, res, next) => {
   if (req.url.match(/\.(css|js|png|jpg|jpeg|gif|ico|svg)$/)) {
-    res.setHeader('Cache-Control', 'public, max-age=86400');
+    // Apply long-term caching for versioned (hashed) assets
+    if (req.url.match(/\.[0-9a-fA-F]{8,}\./)) {
+      res.setHeader('Cache-Control', 'public, max-age=2592000, immutable');
+    } else {
+      res.setHeader('Cache-Control', 'public, max-age=86400');
+    }
   } else {
     res.setHeader('Cache-Control', 'no-cache');
   }


### PR DESCRIPTION
## Summary
- set 30-day immutable caching for hashed files in `server.js`

## Testing
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_687f066bfcd88324ae57a5fa36ac4ff4