### PR TITLE
Implement recado deletion

### DIFF
--- a/public/js/recados.js
+++ b/public/js/recados.js
@@ -246,6 +246,19 @@ function atualizarTotalResultados(total) {
   if (el) el.textContent = `${total} recado${total!==1?'s':''} encontrado${total!==1?'s':''}`;
 }
 
+/**
+ * Exclui um recado após confirmação e atualiza a lista
+ */
+async function excluirRecado(id) {
+  if (!confirm('Excluir recado?')) return;
+  try {
+    await API.deleteRecado(id);
+    carregarRecados(currentPage);
+  } catch (err) {
+    Toast.error(err.message || 'Erro ao excluir recado');
+  }
+}
+
 // Expõe globalmente
 window.aplicarFiltros      = aplicarFiltros;
 window.limparFiltros       = limparFiltros;


### PR DESCRIPTION
## Summary
- add support for deleting recados

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_687ff3aca5d4832485556e5f04b2efc6