### PR TITLE
Remove unsafe-inline from CSP styleSrc

### DIFF
--- a/server.js
+++ b/server.js
@@ -35,7 +35,7 @@ app.use(helmet({
     directives: {
       defaultSrc: ["'self'"],
       scriptSrc:  ["'self'"],
-      styleSrc:   ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
+      styleSrc:   ["'self'", "https://fonts.googleapis.com"],
       fontSrc:    ["'self'", "https://fonts.gstatic.com"],
       imgSrc:     ["'self'", "data:", "https:"],
       connectSrc: ["'self'"],


### PR DESCRIPTION
## Summary
- strip `'unsafe-inline'` from Helmet's `styleSrc`
- keep `scriptSrc`/`styleSrc` to only required origins (self + Google Fonts)

## Testing
- `npm test` *(fails: No tests found)*
- `curl -I http://localhost:3000/`
- `curl -I http://localhost:3000/recados`


------
https://chatgpt.com/codex/tasks/task_e_68b71760f55c8324bcb059afa2e8a9ed