### PR TITLE
Consolidate stats endpoint and update dashboard keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ POST   /api/recados
 PUT    /api/recados/:id
 PATCH  /api/recados/:id/situacao
 DELETE /api/recados/:id
-GET    /api/stats/dashboard
+GET    /api/stats
 GET    /api/stats/por-destinatario
 
 📊 Dashboard

--- a/design_sistema.md
+++ b/design_sistema.md
@@ -54,7 +54,7 @@ CREATE INDEX idx_remetente_nome ON recados(remetente_nome);
 - `GET /api/recados?remetente=nome`
 
 ### 3. Estatísticas
-- `GET /api/stats/dashboard` - Estatísticas gerais
+- `GET /api/stats` - Estatísticas gerais
 - `GET /api/stats/por-destinatario` - Recados por destinatário
 - `GET /api/stats/por-situacao` - Distribuição por situação
 

--- a/models/recado.js
+++ b/models/recado.js
@@ -194,16 +194,20 @@ class RecadoModel {
 
     // Estatísticas
     getStats() {
-        const totalStmt     = this.db.prepare('SELECT COUNT(*) as total FROM recados');
-        const pendenteStmt  = this.db.prepare("SELECT COUNT(*) as total FROM recados WHERE situacao = 'pendente'");
-        const andamentoStmt = this.db.prepare("SELECT COUNT(*) as total FROM recados WHERE situacao = 'em_andamento'");
-        const resolvidoStmt = this.db.prepare("SELECT COUNT(*) as total FROM recados WHERE situacao = 'resolvido'");
-
+        const stmt = this.db.prepare(`
+            SELECT
+                COUNT(*) AS total,
+                SUM(CASE WHEN situacao = 'pendente' THEN 1 ELSE 0 END)      AS pendente,
+                SUM(CASE WHEN situacao = 'em_andamento' THEN 1 ELSE 0 END) AS em_andamento,
+                SUM(CASE WHEN situacao = 'resolvido' THEN 1 ELSE 0 END)    AS resolvido
+            FROM recados
+        `);
+        const row = stmt.get();
         return {
-            total:     totalStmt.get().total,
-            pendentes: pendenteStmt.get().total,
-            andamento: andamentoStmt.get().total,
-            resolvidos: resolvidoStmt.get().total,
+            total:        row.total,
+            pendente:     row.pendente,
+            em_andamento: row.em_andamento,
+            resolvido:    row.resolvido,
         };
     }
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -87,7 +87,7 @@ const API = {
   async deleteRecado(id) { return this.request(`/recados/${id}`, { method: 'DELETE' }); },
 
   // Estatísticas pro Dashboard
-  async getStats() { return this.request('/stats/dashboard'); },
+  async getStats() { return this.request('/stats'); },
   async getStatsByDestinatario() { return this.request('/stats/por-destinatario'); },
 
   // Recados recentes pro Dashboard

--- a/routes/20-07-api.js
+++ b/routes/20-07-api.js
@@ -182,8 +182,8 @@ router.delete('/recados/:id', validateId, async (req, res) => {
     }
 });
 
-// GET /api/stats/dashboard - Estatísticas gerais
-router.get('/stats/dashboard', async (req, res) => {
+// GET /api/stats - Estatísticas gerais
+router.get('/stats', async (req, res) => {
     try {
         const stats = RecadoModel.getStats();
         

--- a/routes/api.js
+++ b/routes/api.js
@@ -153,9 +153,9 @@ router.delete(
 );
 
 // ───────────────────────────────────────────────────────────
-// GET /api/stats/dashboard – estatísticas gerais
+// GET /api/stats – estatísticas gerais
 // ───────────────────────────────────────────────────────────
-router.get('/stats/dashboard', wrap((_, res) => {
+router.get('/stats', wrap((_, res) => {
   const data = RecadoModel.getStats();
   res.json({ success: true, data });
 }));


### PR DESCRIPTION
## Summary
- Use a single SQL query with conditional sums in `getStats` to gather totals for each status
- Serve dashboard statistics via `GET /api/stats` and update frontend API helper
- Refresh documentation and legacy route references

## Testing
- `curl -s http://localhost:3000/api/stats`
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b729ab3bf083248e1f9d2e8cef07f1