### PR TITLE
feat: serve toast bundle

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -95,7 +95,6 @@ const API = {
 };
 
 // Notificações e modais (mantidos conforme original)
-//const Toast = { error: msg => console.error(msg) };
 const Modal = { /* … */ };
 
 

--- a/public/js/recados.js
+++ b/public/js/recados.js
@@ -6,11 +6,6 @@ const itemsPerPagina = 20;
 // compatibilidade com versões antigas
 const itemsPorPagina = itemsPerPagina;
 
-// Fallback para Toast.error
-if (typeof window.Toast !== 'object') {
-  window.Toast = { error: msg => console.error(msg) };
-}
-
 /**
  * Inicializa filtros a partir da URL e preenche o formulário
  */

--- a/public/js/utils.js
+++ b/public/js/utils.js
@@ -59,32 +59,6 @@ const Loading = {
   }
 };
 
-/** Toast notifications */
-const Toast = {
-  container: null,
-  _create(message, type) {
-    if (!Toast.container) {
-      Toast.container = document.createElement('div');
-      Toast.container.className = 'toast-container';
-      document.body.appendChild(Toast.container);
-    }
-    const el = document.createElement('div');
-    el.className = `toast toast-${type}`;
-    el.textContent = message;
-    Toast.container.appendChild(el);
-    requestAnimationFrame(() => el.classList.add('show'));
-    setTimeout(() => {
-      el.classList.remove('show');
-      el.addEventListener('transitionend', () => el.remove());
-    }, 3000);
-  },
-  success(msg) { Toast._create(msg, 'success'); },
-  warning(msg) { Toast._create(msg, 'warning'); },
-  error(msg) { Toast._create(msg, 'error'); },
-  info(msg) { Toast._create(msg, 'info'); }
-};
-
 // Expose globally
 window.Form = Form;
 window.Loading = Loading;
-window.Toast = Toast;

--- a/server.js
+++ b/server.js
@@ -79,6 +79,51 @@ app.use((req, res, next) => {
   next();
 });
 
+app.get('/js/toast.js', (req, res) => {
+  res
+    .type('application/javascript')
+    .send(`(function (root, factory) {
+  if (typeof module === 'object' && module.exports) {
+    const mod = factory();
+    module.exports = mod;
+    module.exports.default = mod;
+  } else if (typeof define === 'function' && define.amd) {
+    define([], factory);
+  } else {
+    root.Toast = factory();
+  }
+}(typeof self !== 'undefined' ? self : this, function () {
+  if (typeof window !== 'undefined' && window.Toast) return window.Toast;
+  const Toast = {
+    container: null,
+    _create(message, type) {
+      if (!Toast.container) {
+        Toast.container = document.createElement('div');
+        Toast.container.className = 'toast-container';
+        document.body.appendChild(Toast.container);
+      }
+      const el = document.createElement('div');
+      el.className = 'toast toast-' + type;
+      el.textContent = message;
+      Toast.container.appendChild(el);
+      requestAnimationFrame(() => el.classList.add('show'));
+      setTimeout(() => {
+        el.classList.remove('show');
+        el.addEventListener('transitionend', () => el.remove());
+      }, 3000);
+    },
+    success(msg) { Toast._create(msg, 'success'); },
+    warning(msg) { Toast._create(msg, 'warning'); },
+    error(msg) { Toast._create(msg, 'error'); },
+    info(msg) { Toast._create(msg, 'info'); }
+  };
+  if (typeof window !== 'undefined' && !window.Toast) {
+    window.Toast = Toast;
+  }
+  return Toast;
+}));`);
+});
+
 app.use(express.static(path.join(__dirname, 'public')));
 
 // ─── Rotas ───────────────────────────────────────────────────────────────────

--- a/views/404.ejs
+++ b/views/404.ejs
@@ -27,6 +27,7 @@
     </div>
   </main>
 
+  <script src="/js/toast.js" defer></script>
   <script src="/js/utils.js" defer></script>
   <script src="/js/app.js" defer></script>
   <script src="/js/navbar.js" defer></script>

--- a/views/editar-recado.ejs
+++ b/views/editar-recado.ejs
@@ -36,6 +36,7 @@
     </div>
   </main>
 
+  <script src="/js/toast.js" defer></script>
   <script src="/js/utils.js" defer></script>
   <script src="/js/app.js" defer></script>
   <script src="/js/editar-recado.js" defer></script>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -89,6 +89,7 @@
         </div>
     </main>
 
+    <script src="/js/toast.js" defer></script>
     <script src="/js/utils.js" defer></script>
     <script src="/js/app.js" defer></script>
     <script src="/js/navbar.js" defer></script>

--- a/views/novo-recado.ejs
+++ b/views/novo-recado.ejs
@@ -101,6 +101,7 @@
             </div>
         </div>
     </main>
+    <script src="/js/toast.js" defer></script>
     <script src="/js/utils.js" defer></script>
     <script src="/js/app.js" defer></script>
     <script src="/js/navbar.js" defer></script>

--- a/views/recados.ejs
+++ b/views/recados.ejs
@@ -73,6 +73,7 @@
         </div>
     </main>
 
+    <script src="/js/toast.js" defer></script>
     <script src="/js/utils.js" defer></script>
     <script src="/js/app.js" defer></script>
     <script src="/js/recados.js" defer></script>

--- a/views/relatorios.ejs
+++ b/views/relatorios.ejs
@@ -51,6 +51,7 @@
     </div>
   </main>
 
+  <script src="/js/toast.js" defer></script>
   <script src="/js/utils.js" defer></script>
   <script src="/js/app.js" defer></script>
   <script src="/js/navbar.js" defer></script>

--- a/views/visualizar-recado.ejs
+++ b/views/visualizar-recado.ejs
@@ -20,6 +20,7 @@
     </div>
   </main>
 
+  <script src="/js/toast.js" defer></script>
   <script src="/js/utils.js" defer></script>
   <script src="/js/app.js" defer></script>
   <script src="/js/navbar.js" defer></script>


### PR DESCRIPTION
## Summary
- add dynamic /js/toast.js route serving a UMD singleton
- remove inline Toast implementations and use shared bundle across pages
- load new toast bundle in all views

## Testing
- `npm test -- --passWithNoTests`
- `curl -s http://localhost:3000/js/toast.js | head`
- `curl -s http://localhost:3000/ | head`
- `curl -s http://localhost:3000/recados | head`


------
https://chatgpt.com/codex/tasks/task_e_68b72bb345a483249da64dd97a765851