### PR TITLE
Serve recados bundle with layout query helper

### DIFF
--- a/server.js
+++ b/server.js
@@ -110,8 +110,20 @@ const sendAppBundle = (req, res) => {
   res.type('application/javascript').send(wrapped);
 };
 
+const sendRecadosBundle = (req, res) => {
+  const recadosJs = fs.readFileSync(path.join(jsDir, 'recados.js'), 'utf8');
+  const helper = "const q = sel => document.querySelector(sel);\n";
+  const content =
+    helper +
+    recadosJs
+      .replace(/document.getElementById\('listaRecados'\)/g, "q('#listaRecados, #recadosContainer')")
+      .replace(/document.getElementById\('totalResultados'\)/g, "q('#totalResultados, #totalRecados')");
+  res.type('application/javascript').send(content);
+};
+
 app.get('/js/app.js', sendAppBundle);
 app.get('/js/utils.js', sendAppBundle);
+app.get('/js/recados.js', sendRecadosBundle);
 
 app.get('/js/toast.js', (req, res) => {
   res


### PR DESCRIPTION
## Summary
- Serve `/js/recados.js` through a shadow bundle that injects a `q` helper and supports legacy/new layout IDs

## Testing
- `npm test` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b73056a0a08324b6bc866456b746a6