### PR TITLE
Add tests for recado stats API

### DIFF
--- a/__tests__/api.recados.test.js
+++ b/__tests__/api.recados.test.js
@@ -1,0 +1,79 @@
+const path = require('path');
+const fs = require('fs');
+const Database = require('better-sqlite3');
+const express = require('express');
+const request = require('supertest');
+let app;
+const dbPath = path.join(__dirname, '..', 'data', 'recados.db');
+
+beforeAll(() => {
+  fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+  const db = new Database(dbPath);
+  let schema = fs.readFileSync(
+    path.join(__dirname, '..', 'migrations', 'schema_20250718.sql'),
+    'utf8'
+  );
+  schema = schema.replace(/CREATE TABLE sqlite_sequence\(name,seq\);/i, '');
+  db.exec(schema);
+  db.close();
+  const apiRoutes = require('../routes/api');
+  app = express();
+  app.use(express.json());
+  app.use('/api', apiRoutes);
+});
+
+afterEach(() => {
+  const db = require('../config/database').getDatabase();
+  db.exec('DELETE FROM recados');
+});
+
+afterAll(() => {
+  const dbManager = require('../config/database');
+  dbManager.close();
+  if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
+  try {
+    fs.rmdirSync(path.dirname(dbPath));
+  } catch (err) {
+    // ignore
+  }
+});
+
+describe('API endpoints', () => {
+  test('GET /api/stats returns stats object', async () => {
+    const payload = {
+      data_ligacao: '2025-01-01',
+      hora_ligacao: '10:00',
+      destinatario: 'Destinatario',
+      remetente_nome: 'Remetente',
+      assunto: 'Assunto de teste'
+    };
+    const createRes = await request(app).post('/api/recados').send(payload);
+    expect(createRes.status).toBe(201);
+    const res = await request(app).get('/api/stats');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('success', true);
+    expect(res.body.data).toMatchObject({
+      total: 1,
+      pendente: 1,
+      em_andamento: 0,
+      resolvido: 0
+    });
+  });
+
+  test('DELETE /api/recados/:id removes recado', async () => {
+    const payload = {
+      data_ligacao: '2025-01-01',
+      hora_ligacao: '10:00',
+      destinatario: 'Destinatario',
+      remetente_nome: 'Remetente',
+      assunto: 'Teste assunto'
+    };
+    const createRes = await request(app).post('/api/recados').send(payload);
+    expect(createRes.status).toBe(201);
+    const id = createRes.body.data.id;
+
+    const deleteRes = await request(app).delete(`/api/recados/${id}`);
+    expect(deleteRes.status).toBe(200);
+    expect(deleteRes.body).toEqual({ success: true });
+  });
+});

--- a/__tests__/recado.model.test.js
+++ b/__tests__/recado.model.test.js
@@ -1,0 +1,38 @@
+const path = require('path');
+const fs = require('fs');
+const Database = require('better-sqlite3');
+let RecadoModel;
+
+const dbPath = path.join(__dirname, '..', 'data', 'recados.db');
+
+beforeAll(() => {
+  fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+  const db = new Database(dbPath);
+  let schema = fs.readFileSync(
+    path.join(__dirname, '..', 'migrations', 'schema_20250718.sql'),
+    'utf8'
+  );
+  schema = schema.replace(/CREATE TABLE sqlite_sequence\(name,seq\);/i, '');
+  db.exec(schema);
+  db.close();
+  RecadoModel = require('../models/recado');
+});
+
+afterAll(() => {
+  const dbManager = require('../config/database');
+  dbManager.close();
+  if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
+  try {
+    fs.rmdirSync(path.dirname(dbPath));
+  } catch (err) {
+    // ignore if directory not empty
+  }
+});
+
+test('getStats returns object with expected keys', () => {
+  const stats = RecadoModel.getStats();
+  expect(stats).toHaveProperty('total');
+  expect(stats).toHaveProperty('pendente');
+  expect(stats).toHaveProperty('em_andamento');
+  expect(stats).toHaveProperty('resolvido');
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "jsdom": "^24.0.0",
         "lighthouse": "^12.8.0",
         "nodemon": "^3.0.2",
+        "supertest": "^7.1.4",
         "ts-jest": "^29.4.0",
         "ts-node": "^10.9.2",
         "typescript": "^5.8.3"
@@ -1236,6 +1237,19 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
@@ -1833,6 +1847,16 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
+      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@paulirish/trace_engine": {
@@ -2515,6 +2539,13 @@
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ast-types": {
       "version": "0.13.4",
@@ -3695,6 +3726,16 @@
         "node": ">=16"
       }
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/compressible": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
@@ -3796,6 +3837,13 @@
       "engines": {
         "node": ">=6.6.0"
       }
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cors": {
       "version": "2.8.5",
@@ -4761,6 +4809,17 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -5384,6 +5443,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
@@ -5563,6 +5629,24 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -7611,6 +7695,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -7623,6 +7717,19 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/mime-db": {
@@ -11004,6 +11111,66 @@
       },
       "peerDependencies": {
         "postcss": "^8.4.32"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "10.2.3",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.2.3.tgz",
+      "integrity": "sha512-y/hkYGeXAj7wUMjxRbB21g/l6aAEituGXM9Rwl4o20+SX3e8YOSV6BxFXl+dL3Uk0mjSL3kCbNkwURm8/gEDig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.4",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.2"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/superagent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supertest": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.1.4.tgz",
+      "integrity": "sha512-tjLPs7dVyqgItVFirHYqe2T+MfWc2VOBQ8QFKKbWTA3PU7liZR8zoSpAi/C1k1ilm9RsXIKYf197oap9wXGVYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^10.2.3"
+      },
+      "engines": {
+        "node": ">=14.18.0"
       }
     },
     "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "jest --coverage",
+    "test": "jest --runInBand --coverage",
     "lighthouse": "lighthouse http://localhost:3000 --output html --output json --output-path ./lighthouse-reports/report"
   },
   "keywords": [
@@ -29,12 +29,13 @@
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",
-    "jest": "^30.0.5",
-    "jsdom": "^24.0.0",
     "cssnano": "^7.1.0",
     "cssnano-cli": "^1.0.5",
+    "jest": "^30.0.5",
+    "jsdom": "^24.0.0",
     "lighthouse": "^12.8.0",
     "nodemon": "^3.0.2",
+    "supertest": "^7.1.4",
     "ts-jest": "^29.4.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.3"


### PR DESCRIPTION
## Summary
- add unit test for `RecadoModel.getStats` ensuring expected keys
- add supertest coverage for `/api/stats` and deleting recados
- run jest sequentially to avoid DB conflicts and include supertest dev dependency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b73728e3948324a872500dc2657312