### PR TITLE
Configure trust proxy and disable rate-limit header validation

### DIFF
--- a/server.js
+++ b/server.js
@@ -55,8 +55,10 @@ app.use(helmet({
 }));
 
 if (process.env.NODE_ENV === 'production') {
+  app.set('trust proxy', 1);
   if (validateOrigin) app.use(validateOrigin);
   const limiter = rateLimit({
+    validate: false,
     windowMs: 15 * 60 * 1000, // 15 minutos
     max: 100,
     message: {


### PR DESCRIPTION
## Summary
- set Express trust proxy in production before applying rate limiting
- disable express-rate-limit header validation to support environments without proxy

## Testing
- `npm test`
- `npm start` (server boot)

------
https://chatgpt.com/codex/tasks/task_e_68b7412935c88324bb871992cc7dd1af