### PR TITLE
Validate ordering parameters in RecadoModel

### DIFF
--- a/__tests__/recado.model.test.js
+++ b/__tests__/recado.model.test.js
@@ -106,3 +106,15 @@ test('count ignores pagination options', () => {
   const total = RecadoModel.count(filters);
   expect(total).toBe(2);
 });
+
+test('findAll defaults to safe ordering when invalid params provided', () => {
+  const defaultList = RecadoModel.findAll({});
+  const invalidList = RecadoModel.findAll({ orderBy: 'malicious', orderDir: 'INVALID' });
+  expect(invalidList).toEqual(defaultList);
+});
+
+test('findAll defaults to DESC when orderDir invalid', () => {
+  const expected = RecadoModel.findAll({ orderBy: 'id', orderDir: 'DESC' });
+  const invalidDir = RecadoModel.findAll({ orderBy: 'id', orderDir: 'bad' });
+  expect(invalidDir).toEqual(expected);
+});

--- a/models/recado.js
+++ b/models/recado.js
@@ -3,6 +3,17 @@ const dbManager = require('../config/database');
 class RecadoModel {
     constructor() {
         this.db = dbManager.getDatabase();
+        this.allowedOrderBy = [
+            'id',
+            'data_ligacao',
+            'hora_ligacao',
+            'destinatario',
+            'remetente_nome',
+            'situacao',
+            'criado_em',
+            'atualizado_em'
+        ];
+        this.allowedOrderDir = ['ASC', 'DESC'];
     }
 
     // Helper para construir filtros reutilizáveis
@@ -91,8 +102,11 @@ class RecadoModel {
         let query = `SELECT * FROM recados WHERE 1=1${clause}`;
 
         // Ordenação
-        const orderBy = filters.orderBy || 'criado_em';
-        const orderDir = filters.orderDir || 'DESC';
+        const orderBy = this.allowedOrderBy.includes(filters.orderBy)
+            ? filters.orderBy
+            : 'criado_em';
+        const dir = (filters.orderDir || '').toUpperCase();
+        const orderDir = this.allowedOrderDir.includes(dir) ? dir : 'DESC';
         query += ` ORDER BY ${orderBy} ${orderDir}`;
 
         // Paginação


### PR DESCRIPTION
## Summary
- guard against invalid order columns and directions in RecadoModel
- expand model tests to cover invalid ordering options

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b750bac8b883248cc062e16f82819b