### PR TITLE
Add model and API integration tests

### DIFF
--- a/__tests__/api.recados.test.js
+++ b/__tests__/api.recados.test.js
@@ -6,6 +6,15 @@ const request = require('supertest');
 let app;
 const dbPath = path.join(__dirname, '..', 'data', 'recados.db');
 
+const makePayload = (overrides = {}) => ({
+  data_ligacao: '2025-01-01',
+  hora_ligacao: '10:00',
+  destinatario: 'Destinatario',
+  remetente_nome: 'Remetente',
+  assunto: 'Assunto de teste',
+  ...overrides,
+});
+
 beforeAll(() => {
   fs.mkdirSync(path.dirname(dbPath), { recursive: true });
   const db = new Database(dbPath);
@@ -39,41 +48,81 @@ afterAll(() => {
 });
 
 describe('API endpoints', () => {
-  test('GET /api/stats returns stats object', async () => {
-    const payload = {
-      data_ligacao: '2025-01-01',
-      hora_ligacao: '10:00',
-      destinatario: 'Destinatario',
-      remetente_nome: 'Remetente',
-      assunto: 'Assunto de teste'
-    };
-    const createRes = await request(app).post('/api/recados').send(payload);
-    expect(createRes.status).toBe(201);
-    const res = await request(app).get('/api/stats');
-    expect(res.status).toBe(200);
+  test('POST /api/recados creates a new record', async () => {
+    const res = await request(app).post('/api/recados').send(makePayload());
+    expect(res.status).toBe(201);
     expect(res.body).toHaveProperty('success', true);
-    expect(res.body.data).toMatchObject({
-      total: 1,
-      pendente: 1,
-      em_andamento: 0,
-      resolvido: 0
-    });
+    expect(res.body.data).toHaveProperty('id');
   });
 
-  test('DELETE /api/recados/:id removes recado', async () => {
-    const payload = {
-      data_ligacao: '2025-01-01',
-      hora_ligacao: '10:00',
-      destinatario: 'Destinatario',
-      remetente_nome: 'Remetente',
-      assunto: 'Teste assunto'
-    };
-    const createRes = await request(app).post('/api/recados').send(payload);
-    expect(createRes.status).toBe(201);
-    const id = createRes.body.data.id;
+  test('GET /api/recados lists with filters and pagination', async () => {
+    await request(app).post('/api/recados').send(makePayload({ situacao: 'pendente' }));
+    await request(app).post('/api/recados').send(makePayload({ situacao: 'em_andamento' }));
+    await request(app).post('/api/recados').send(makePayload({ situacao: 'pendente', destinatario: 'Outro' }));
 
+    const res = await request(app).get('/api/recados?situacao=pendente&limit=1&offset=0&orderBy=criado_em&orderDir=ASC');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.pagination).toMatchObject({ total: 2, limit: 1, offset: 0, hasMore: true });
+  });
+
+  test('GET /api/recados/:id returns recado and 404 if not found', async () => {
+    const createRes = await request(app).post('/api/recados').send(makePayload());
+    const id = createRes.body.data.id;
+    const okRes = await request(app).get(`/api/recados/${id}`);
+    expect(okRes.status).toBe(200);
+    expect(okRes.body.data.id).toBe(id);
+    const notFound = await request(app).get('/api/recados/9999');
+    expect(notFound.status).toBe(404);
+  });
+
+  test('PUT /api/recados/:id updates recado', async () => {
+    const createRes = await request(app).post('/api/recados').send(makePayload());
+    const id = createRes.body.data.id;
+    const updateRes = await request(app)
+      .put(`/api/recados/${id}`)
+      .send(makePayload({ assunto: 'Atualizado', situacao: 'resolvido' }));
+    expect(updateRes.status).toBe(200);
+    expect(updateRes.body.data.assunto).toBe('Atualizado');
+    const notFound = await request(app)
+      .put('/api/recados/9999')
+      .send(makePayload());
+    expect(notFound.status).toBe(404);
+  });
+
+  test('PATCH /api/recados/:id/situacao updates status', async () => {
+    const createRes = await request(app).post('/api/recados').send(makePayload());
+    const id = createRes.body.data.id;
+    const patchRes = await request(app)
+      .patch(`/api/recados/${id}/situacao`)
+      .send({ situacao: 'resolvido' });
+    expect(patchRes.status).toBe(200);
+    expect(patchRes.body.data.situacao).toBe('resolvido');
+    const notFound = await request(app)
+      .patch('/api/recados/9999/situacao')
+      .send({ situacao: 'pendente' });
+    expect(notFound.status).toBe(404);
+  });
+
+  test('DELETE /api/recados/:id removes recado and handles missing id', async () => {
+    const createRes = await request(app).post('/api/recados').send(makePayload());
+    const id = createRes.body.data.id;
     const deleteRes = await request(app).delete(`/api/recados/${id}`);
     expect(deleteRes.status).toBe(200);
     expect(deleteRes.body).toEqual({ success: true });
+    const notFound = await request(app).delete(`/api/recados/${id}`);
+    expect(notFound.status).toBe(404);
+  });
+
+  test('POST /api/recados returns 400 for invalid payload', async () => {
+    const res = await request(app).post('/api/recados').send({ destinatario: '' });
+    expect(res.status).toBe(400);
+  });
+
+  test('GET /api/stats returns global statistics', async () => {
+    await request(app).post('/api/recados').send(makePayload());
+    const res = await request(app).get('/api/stats');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('data.total', 1);
   });
 });

--- a/__tests__/recado.model.test.js
+++ b/__tests__/recado.model.test.js
@@ -118,3 +118,57 @@ test('findAll defaults to DESC when orderDir invalid', () => {
   const invalidDir = RecadoModel.findAll({ orderBy: 'id', orderDir: 'bad' });
   expect(invalidDir).toEqual(expected);
 });
+
+test('create stores and returns a new recado with default status', () => {
+  const sample = {
+    data_ligacao: '2024-03-01',
+    hora_ligacao: '13:00',
+    destinatario: 'Grace',
+    remetente_nome: 'Heidi',
+    assunto: 'Follow up'
+  };
+  const created = RecadoModel.create(sample);
+  expect(created).toMatchObject({
+    ...sample,
+    situacao: 'pendente'
+  });
+  expect(created).toHaveProperty('id');
+  expect(RecadoModel.count({})).toBe(5);
+});
+
+test('findAll supports pagination with limit and offset', () => {
+  const full = RecadoModel.findAll({ orderBy: 'id', orderDir: 'ASC' });
+  const paged = RecadoModel.findAll({ orderBy: 'id', orderDir: 'ASC', limit: 2, offset: 1 });
+  expect(paged).toEqual(full.slice(1, 3));
+});
+
+test('update modifies all fields of a recado', () => {
+  const original = RecadoModel.findAll({ orderBy: 'id', orderDir: 'ASC' })[0];
+  const updated = RecadoModel.update(original.id, {
+    ...original,
+    assunto: 'Updated assunto',
+    situacao: 'em_andamento'
+  });
+  expect(updated.assunto).toBe('Updated assunto');
+  expect(updated.situacao).toBe('em_andamento');
+});
+
+test('updateSituacao changes only the status field', () => {
+  const recado = RecadoModel.findAll({ orderBy: 'id', orderDir: 'ASC' })[0];
+  const ok = RecadoModel.updateSituacao(recado.id, 'resolvido');
+  expect(ok).toBe(true);
+  const fetched = RecadoModel.findById(recado.id);
+  expect(fetched.situacao).toBe('resolvido');
+});
+
+test('delete removes recado and returns true', () => {
+  const recado = RecadoModel.findAll({ orderBy: 'id', orderDir: 'ASC' })[0];
+  const ok = RecadoModel.delete(recado.id);
+  expect(ok).toBe(true);
+  expect(RecadoModel.findById(recado.id)).toBeUndefined();
+  expect(RecadoModel.count({})).toBe(3);
+});
+
+test('count with filter returns number of matching records', () => {
+  expect(RecadoModel.count({ situacao: 'pendente' })).toBe(2);
+});


### PR DESCRIPTION
## Summary
- add unit tests for RecadoModel covering create, pagination, update, status update, deletion and count filters
- exercise API endpoints for recados with success and error scenarios, including pagination and invalid requests
- ensure SQLite state resets between tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b752c11dc08324a1915a46d5c6ec8b