### PR TITLE
Ensure RecadoModel fails fast without DB connection

### DIFF
--- a/__tests__/recado.model.test.js
+++ b/__tests__/recado.model.test.js
@@ -172,3 +172,17 @@ test('delete removes recado and returns true', () => {
 test('count with filter returns number of matching records', () => {
   expect(RecadoModel.count({ situacao: 'pendente' })).toBe(2);
 });
+
+test('methods throw error when database instance missing', () => {
+  const originalDb = RecadoModel.db;
+  RecadoModel.db = null;
+  expect(() => RecadoModel.findAll({})).toThrow('Database connection is not initialized');
+  RecadoModel.db = originalDb;
+});
+
+test('methods throw error when database connection is closed', () => {
+  const dbManager = require('../config/database');
+  dbManager.close();
+  expect(() => RecadoModel.findAll({})).toThrow('Database connection is not initialized');
+  RecadoModel.db = dbManager.getDatabase();
+});

--- a/config/database.js
+++ b/config/database.js
@@ -14,15 +14,20 @@ class DatabaseManager {
    * Retorna uma instância única do banco. Cria o arquivo se não existir.
    */
   getDatabase() {
-    if (!this.db) {
+    if (!this.db || !this.db.open) {
       const dbPath = path.join(__dirname, '..', 'data', 'recados.db');
       try {
+        console.info(`[DatabaseManager] Inicializando banco em ${dbPath}`);
         this.db = new Database(dbPath);
         // Habilitar chaves estrangeiras, se necessário
         this.db.pragma('foreign_keys = ON');
       } catch (err) {
-        console.error('Erro ao inicializar o banco de dados:', err);
+        console.error(
+          `[DatabaseManager] Falha ao inicializar o banco em ${dbPath}: ${err.message}`,
+          err
+        );
         this.db = null;
+        throw err;
       }
     }
     return this.db;

--- a/models/recado.js
+++ b/models/recado.js
@@ -16,6 +16,12 @@ class RecadoModel {
         this.allowedOrderDir = ['ASC', 'DESC'];
     }
 
+    _ensureDb() {
+        if (!this.db || !this.db.open) {
+            throw new Error('Database connection is not initialized');
+        }
+    }
+
     // Helper para construir filtros reutilizáveis
     _buildFilterQuery(filters = {}) {
         let clause = '';
@@ -66,6 +72,7 @@ class RecadoModel {
 
     // Criar novo recado
     create(recadoData) {
+        this._ensureDb();
         const stmt = this.db.prepare(`
             INSERT INTO recados (
                 data_ligacao, hora_ligacao, destinatario, remetente_nome,
@@ -92,12 +99,14 @@ class RecadoModel {
 
     // Buscar por ID
     findById(id) {
+        this._ensureDb();
         const stmt = this.db.prepare('SELECT * FROM recados WHERE id = ?');
         return stmt.get(id);
     }
 
     // Listar todos com filtros
     findAll(filters = {}) {
+        this._ensureDb();
         const { clause, params } = this._buildFilterQuery(filters);
         let query = `SELECT * FROM recados WHERE 1=1${clause}`;
 
@@ -127,6 +136,7 @@ class RecadoModel {
     // Este método pode não existir em versões antigas do sistema. Caso
     // necessite adicionar suporte à contagem de registros, implemente aqui.
     count(filters = {}) {
+        this._ensureDb();
         const { clause, params } = this._buildFilterQuery(filters);
         const query = `SELECT COUNT(*) as total FROM recados WHERE 1=1${clause}`;
         const stmt = this.db.prepare(query);
@@ -136,6 +146,7 @@ class RecadoModel {
 
     // Atualizar recado
     update(id, recadoData) {
+        this._ensureDb();
         const stmt = this.db.prepare(`
             UPDATE recados SET
                 data_ligacao = ?, hora_ligacao = ?, destinatario = ?,
@@ -164,10 +175,11 @@ class RecadoModel {
 
     // Atualizar apenas situação
     updateSituacao(id, situacao) {
+        this._ensureDb();
         const stmt = this.db.prepare(`
-            UPDATE recados SET 
-                situacao = ?, 
-                atualizado_em = CURRENT_TIMESTAMP 
+            UPDATE recados SET
+                situacao = ?,
+                atualizado_em = CURRENT_TIMESTAMP
             WHERE id = ?
         `);
         const result = stmt.run(situacao, id);
@@ -176,6 +188,7 @@ class RecadoModel {
 
     // Excluir recado
     delete(id) {
+        this._ensureDb();
         const stmt = this.db.prepare('DELETE FROM recados WHERE id = ?');
         const result = stmt.run(id);
         return result.changes > 0;
@@ -183,6 +196,7 @@ class RecadoModel {
 
     // Estatísticas
     getStats() {
+        this._ensureDb();
         const stmt = this.db.prepare(`
             SELECT
                 COUNT(*) AS total,
@@ -202,6 +216,7 @@ class RecadoModel {
 
     // Estatísticas agrupadas por destinatário
     getStatsByDestinatario() {
+        this._ensureDb();
         const stmt = this.db.prepare(`
             SELECT destinatario, COUNT(*) as total
             FROM recados
@@ -213,6 +228,7 @@ class RecadoModel {
 
     // Últimos N recados
     getRecentes(limit = 10) {
+        this._ensureDb();
         const stmt = this.db.prepare(`
             SELECT * FROM recados
             ORDER BY criado_em DESC


### PR DESCRIPTION
## Summary
- Ensure all RecadoModel methods verify a live database connection before running queries
- Improve database initialization logging and error surfacing
- Test behavior when database connection is missing or closed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b759029cb08324b4cd8120adbed725