### PR TITLE
Fix date parsing to avoid timezone shift in front-end utils

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -5,17 +5,38 @@ const API_BASE = '/api';
 
 // Utilitários
 const Utils = {
+  /**
+   * Constrói um objeto Date no fuso local a partir de 'YYYY-MM-DD'.
+   */
+  _parseDate(dateString = '') {
+    const [y, m, d] = dateString.split('-').map(Number);
+    return new Date(y, (m || 1) - 1, d || 1);
+  },
+
+  /**
+   * Constrói um objeto Date no fuso local a partir de 'YYYY-MM-DDTHH:mm:ss'.
+   */
+  _parseDateTime(dateString = '') {
+    const [datePart, timePart = ''] = dateString.split(/T| /);
+    const [y, m, d] = datePart.split('-').map(Number);
+    const [h = 0, min = 0, s = 0] = timePart.split(':').map(Number);
+    return new Date(y, (m || 1) - 1, d || 1, h, min, s);
+  },
+
   formatDate(dateString) {
-    const date = new Date(dateString);
+    const date = this._parseDate(dateString);
     return date.toLocaleDateString('pt-BR');
   },
   formatDateTime(dateString) {
-    const date = new Date(dateString);
+    const date = this._parseDateTime(dateString);
     return date.toLocaleString('pt-BR');
   },
   formatDateForInput(dateString) {
-    const date = new Date(dateString);
-    return date.toISOString().split('T')[0];
+    const date = this._parseDate(dateString);
+    const y = date.getFullYear();
+    const m = String(date.getMonth() + 1).padStart(2, '0');
+    const d = String(date.getDate()).padStart(2, '0');
+    return `${y}-${m}-${d}`;
   },
   formatTimeForInput(timeString) {
     return timeString.substring(0, 5);


### PR DESCRIPTION
## Summary
- parse date strings manually to prevent timezone shifts in format helpers
- ensure date rendering in lists still uses `Utils.formatDate`

## Testing
- `TZ=America/Sao_Paulo node - <<'NODE'
const Utils={_parseDate(d=''){const [y,m,day]=d.split('-').map(Number);return new Date(y,(m||1)-1,day||1);},_parseDateTime(dt=''){const [dp,tp='']=dt.split(/T| /);const [y,m,day]=dp.split('-').map(Number);const [h=0,mi=0,s=0]=tp.split(':').map(Number);return new Date(y,(m||1)-1,day||1,h,mi,s);},formatDate(d){return this._parseDate(d).toLocaleDateString('pt-BR');},formatDateTime(dt){return this._parseDateTime(dt).toLocaleString('pt-BR');},formatDateForInput(d){const date=this._parseDate(d);const y=date.getFullYear();const m=String(date.getMonth()+1).padStart(2,'0');const day=String(date.getDate()).padStart(2,'0');return `${y}-${m}-${day}`;}};
const date='2024-06-13';
console.log('Stored:',date);
console.log('Displayed:',Utils.formatDate(date));
NODE`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b768ff94408324a120743ec788588f