### PR TITLE
feat: expand edit recado form

### DIFF
--- a/__tests__/api.recados.test.js
+++ b/__tests__/api.recados.test.js
@@ -11,7 +11,12 @@ const makePayload = (overrides = {}) => ({
   hora_ligacao: '10:00',
   destinatario: 'Destinatario',
   remetente_nome: 'Remetente',
+  remetente_telefone: '11999999999',
+  remetente_email: 'remetente@example.com',
+  horario_retorno: 'Manhã',
   assunto: 'Assunto de teste',
+  situacao: 'pendente',
+  observacoes: 'Observação de teste',
   ...overrides,
 });
 
@@ -49,10 +54,12 @@ afterAll(() => {
 
 describe('API endpoints', () => {
   test('POST /api/recados creates a new record', async () => {
-    const res = await request(app).post('/api/recados').send(makePayload());
+    const payload = makePayload();
+    const res = await request(app).post('/api/recados').send(payload);
     expect(res.status).toBe(201);
     expect(res.body).toHaveProperty('success', true);
     expect(res.body.data).toHaveProperty('id');
+    expect(res.body.data).toMatchObject(payload);
   });
 
   test('GET /api/recados lists with filters and pagination', async () => {
@@ -79,11 +86,25 @@ describe('API endpoints', () => {
   test('PUT /api/recados/:id updates recado', async () => {
     const createRes = await request(app).post('/api/recados').send(makePayload());
     const id = createRes.body.data.id;
+    const updatedPayload = makePayload({
+      data_ligacao: '2025-02-02',
+      hora_ligacao: '11:11',
+      destinatario: 'Destinatario Atualizado',
+      remetente_nome: 'Remetente Atualizado',
+      remetente_telefone: '11888888888',
+      remetente_email: 'novo@example.com',
+      horario_retorno: 'Tarde',
+      assunto: 'Atualizado',
+      situacao: 'resolvido',
+      observacoes: 'Observações atualizadas',
+    });
     const updateRes = await request(app)
       .put(`/api/recados/${id}`)
-      .send(makePayload({ assunto: 'Atualizado', situacao: 'resolvido' }));
+      .send(updatedPayload);
     expect(updateRes.status).toBe(200);
-    expect(updateRes.body.data.assunto).toBe('Atualizado');
+    expect(updateRes.body.data).toMatchObject(updatedPayload);
+    const fetchRes = await request(app).get(`/api/recados/${id}`);
+    expect(fetchRes.body.data).toMatchObject(updatedPayload);
     const notFound = await request(app)
       .put('/api/recados/9999')
       .send(makePayload());

--- a/public/js/editar-recado.js
+++ b/public/js/editar-recado.js
@@ -2,29 +2,48 @@
 // Código extraído de views/editar-recado.ejs
 
 document.addEventListener('DOMContentLoaded', async () => {
-    const form = document.getElementById('formEditarRecado');
-    const id = location.pathname.split('/').pop();
+  const form = document.getElementById('formEditarRecado');
+  const id = location.pathname.split('/').pop();
+  const fields = [
+    'data_ligacao',
+    'hora_ligacao',
+    'destinatario',
+    'remetente_nome',
+    'remetente_telefone',
+    'remetente_email',
+    'horario_retorno',
+    'assunto',
+    'situacao',
+    'observacoes'
+  ];
+
+  try {
+    const { data } = await API.getRecado(id);
+    const safeData = {};
+    fields.forEach(f => (safeData[f] = data[f] ?? ''));
+    Form.populate(form, safeData);
+    document.getElementById('btnCancelar').href = `/visualizar-recado/${id}`;
+  } catch (e) {
+    Toast.error('Erro ao carregar recado');
+  }
+
+  form.addEventListener('submit', async e => {
+    e.preventDefault();
+    const errors = Form.validate(form);
+    if (errors.length) return Toast.error(errors[0]);
     try {
-        const { data } = await API.getRecado(id);
-        Form.populate(form, data);
-        document.getElementById('btnCancelar').href = `/visualizar-recado/${id}`;
-    } catch (e) {
-        Toast.error('Erro ao carregar recado');
+      Loading.show('btnSalvar');
+      const payload = Form.getData(form);
+      fields.forEach(f => {
+        if (!(f in payload)) payload[f] = '';
+      });
+      await API.updateRecado(id, payload);
+      Toast.success('Recado atualizado com sucesso!');
+      setTimeout(() => (window.location.href = `/visualizar-recado/${id}`), 1000);
+    } catch (err) {
+      Toast.error(err.message || 'Erro ao atualizar recado');
+    } finally {
+      Loading.hide('btnSalvar');
     }
-    form.addEventListener('submit', async e => {
-        e.preventDefault();
-        const errors = Form.validate(form);
-        if (errors.length) return Toast.error(errors[0]);
-        try {
-            Loading.show('btnSalvar');
-            const payload = Form.getData(form);
-            await API.updateRecado(id, payload);
-            Toast.success('Recado atualizado com sucesso!');
-            setTimeout(() => window.location.href = `/visualizar-recado/${id}`, 1000);
-        } catch (err) {
-            Toast.error(err.message || 'Erro ao atualizar recado');
-        } finally {
-            Loading.hide('btnSalvar');
-        }
-    });
+  });
 });

--- a/views/editar-recado.ejs
+++ b/views/editar-recado.ejs
@@ -3,36 +3,103 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Editar Recado - Sistema de Recados</title>
+  <title>LATE - Editar Recado</title>
   <link rel="stylesheet" href="<%= cssFile %>" />
 </head>
 <body>
   <%- include('partials/header') %>
 
-  <main class="main" role="main">
-    <div class="container" style="max-width:800px;">
-      <h1>Editar Recado</h1>
-      <form id="formEditarRecado" class="card">
-        <!-- Fieldsets e inputs copiados de novo-recado.html -->
-        <fieldset>
-          <legend>📞 Dados da Ligação</legend>
-          <div class="form-grid-2">
-            <div class="form-group">
-              <label for="data_ligacao" class="form-label required">Data da Ligação</label>
-              <input id="data_ligacao" name="data_ligacao" type="date" class="form-input" required autocomplete="bday" />
-            </div>
-            <div class="form-group">
-              <label for="hora_ligacao" class="form-label required">Hora da Ligação</label>
-              <input id="hora_ligacao" name="hora_ligacao" type="time" class="form-input" required autocomplete="off" />
+  <main class="main">
+    <div class="container">
+      <div style="margin-bottom: 2rem;">
+        <h1 style="font-size: 2rem; font-weight: 700; margin-bottom: 0.5rem;">Editar Recado</h1>
+        <p style="color: var(--text-secondary);">Atualize os dados do recado</p>
+      </div>
+      <div style="max-width: 800px;">
+        <form id="formEditarRecado" class="card">
+          <div class="card-header">
+            <h2 class="card-title">Informações do Recado</h2>
+            <p class="card-subtitle">Revise ou altere as informações necessárias</p>
+          </div>
+          <div class="card-body">
+            <!-- 📞 Dados da Ligação -->
+            <fieldset style="border: 1px solid var(--border-light); border-radius: var(--radius); padding: 1.5rem; margin-bottom: 2rem;">
+              <legend style="padding: 0 0.5rem; font-weight: 600; color: var(--text-primary);">📞 Dados da Ligação</legend>
+              <div class="form-grid-2">
+                <div class="form-group">
+                  <label for="data_ligacao" class="form-label required">Data da Ligação</label>
+                  <input id="data_ligacao" name="data_ligacao" type="date" class="form-input" required data-label="Data da ligação" autocomplete="bday" />
+                </div>
+                <div class="form-group">
+                  <label for="hora_ligacao" class="form-label required">Hora da Ligação</label>
+                  <input id="hora_ligacao" name="hora_ligacao" type="time" class="form-input" required data-label="Hora da ligação" autocomplete="off" />
+                </div>
+              </div>
+              <div class="form-group">
+                <label for="destinatario" class="form-label required">Destinatário</label>
+                <input id="destinatario" name="destinatario" type="text" class="form-input" required data-label="Destinatário" autocomplete="organization" />
+                <div class="form-help">Pessoa ou setor responsável por receber esta mensagem</div>
+              </div>
+            </fieldset>
+
+            <!-- 👤 Dados do Remetente -->
+            <fieldset style="border: 1px solid var(--border-light); border-radius: var(--radius); padding: 1.5rem; margin-bottom: 2rem;">
+              <legend style="padding: 0 0.5rem; font-weight: 600; color: var(--text-primary);">👤 Dados do Remetente</legend>
+              <div class="form-group">
+                <label for="remetente_nome" class="form-label required">Nome do Remetente</label>
+                <input id="remetente_nome" name="remetente_nome" type="text" class="form-input" required data-label="Nome do remetente" autocomplete="name" />
+              </div>
+              <div class="form-grid-2">
+                <div class="form-group">
+                  <label for="remetente_telefone" class="form-label">Telefone</label>
+                  <input id="remetente_telefone" name="remetente_telefone" type="tel" class="form-input" placeholder="(11) 99999-9999" autocomplete="tel" />
+                  <div class="form-help">Telefone para retorno (opcional)</div>
+                </div>
+                <div class="form-group">
+                  <label for="remetente_email" class="form-label">E-mail</label>
+                  <input id="remetente_email" name="remetente_email" type="email" class="form-input" placeholder="email@exemplo.com" autocomplete="email" />
+                  <div class="form-help">E-mail para contato (opcional)</div>
+                </div>
+              </div>
+              <div class="form-group">
+                <label for="horario_retorno" class="form-label">Horário para Retorno</label>
+                <input id="horario_retorno" name="horario_retorno" type="text" class="form-input" placeholder="Ex: Das 9h às 17h, Após 14h, etc." autocomplete="off" />
+                <div class="form-help">Melhor horário para retornar a ligação (opcional)</div>
+              </div>
+            </fieldset>
+
+            <!-- 📝 Conteúdo do Recado -->
+            <fieldset style="border: 1px solid var(--border-light); border-radius: var(--radius); padding: 1.5rem; margin-bottom: 2rem;">
+              <legend style="padding: 0 0.5rem; font-weight: 600; color: var(--text-primary);">📝 Conteúdo do Recado</legend>
+              <div class="form-group">
+                <label for="assunto" class="form-label required">Assunto</label>
+                <input id="assunto" name="assunto" type="text" class="form-input" required data-label="Assunto" autocomplete="off" />
+                <div class="form-help">Descreva brevemente o motivo da ligação</div>
+              </div>
+              <div class="form-group">
+                <label for="observacoes" class="form-label">Observações</label>
+                <textarea id="observacoes" name="observacoes" class="form-textarea" rows="4" autocomplete="off"></textarea>
+                <div class="form-help">Informações adicionais que possam ser úteis (opcional)</div>
+              </div>
+              <div class="form-group">
+                <label for="situacao" class="form-label">Situação</label>
+                <select id="situacao" name="situacao" class="form-select" autocomplete="off">
+                  <option value="pendente">Pendente</option>
+                  <option value="em_andamento">Em Andamento</option>
+                  <option value="resolvido">Resolvido</option>
+                </select>
+                <div class="form-help">Status atual do recado</div>
+              </div>
+            </fieldset>
+          </div>
+          <div class="card-footer">
+            <div style="display: flex; gap: 1rem; justify-content: flex-end;">
+              <a href="#" id="btnCancelar" class="btn btn-outline">Cancelar</a>
+              <button type="submit" class="btn btn-primary" id="btnSalvar">💾 Atualizar Recado</button>
             </div>
           </div>
-        </fieldset>
-        <!-- ... repita para demais grupos (remetente, conteúdo) ... -->
-        <div class="card-footer" style="display:flex;gap:1rem;justify-content:flex-end;">
-          <a href="#" id="btnCancelar" class="btn btn-outline">Cancelar</a>
-          <button type="submit" id="btnSalvar" class="btn btn-primary">💾 Atualizar Recado</button>
-        </div>
-      </form>
+        </form>
+      </div>
     </div>
   </main>
 
@@ -43,3 +110,4 @@
   <script src="/js/navbar.js" defer></script>
 </body>
 </html>
+


### PR DESCRIPTION
## Summary
- mirror new-recado fields on edit page
- populate and submit complete recado payload
- test full payload persistence via API

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b76a3facd483249db49a78aff93b25