### PR TITLE
Handle API errors on reports page

### DIFF
--- a/views/relatorios.ejs
+++ b/views/relatorios.ejs
@@ -59,39 +59,62 @@
 
   <script>
     document.addEventListener('DOMContentLoaded', async () => {
+      const totalEl = document.getElementById('relTotal');
+      const pendEl  = document.getElementById('relPendente');
+      const andEl   = document.getElementById('relAndamento');
+      const resEl   = document.getElementById('relResolvido');
+      const tbody   = document.getElementById('relPorDestinatario');
+
+      // Estatísticas gerais
       try {
         const stats = (await API.getStats()).data;
-        document.getElementById('relTotal').textContent = stats.total;
-        document.getElementById('relPendente').textContent = stats.pendente;
-        document.getElementById('relAndamento').textContent = stats.em_andamento;
-        document.getElementById('relResolvido').textContent = stats.resolvido;
-
-        const porDest = (await API.getStatsByDestinatario()).data;
-        const tbody = document.getElementById('relPorDestinatario');
-        porDest.forEach(r => {
-          const tr = document.createElement('tr');
-
-          const destTd = document.createElement('td');
-          destTd.textContent = r.destinatario;
-          const totalTd = document.createElement('td');
-          totalTd.textContent = r.total;
-          const pendTd = document.createElement('td');
-          pendTd.textContent = r.pendente;
-          const andTd = document.createElement('td');
-          andTd.textContent = r.em_andamento;
-          const resTd = document.createElement('td');
-          resTd.textContent = r.resolvido;
-
-          tr.appendChild(destTd);
-          tr.appendChild(totalTd);
-          tr.appendChild(pendTd);
-          tr.appendChild(andTd);
-          tr.appendChild(resTd);
-
-          tbody.appendChild(tr);
-        });
+        totalEl.textContent = stats.total;
+        pendEl.textContent  = stats.pendente;
+        andEl.textContent   = stats.em_andamento;
+        resEl.textContent   = stats.resolvido;
       } catch (e) {
-        console.error('Erro ao carregar relatórios:', e);
+        console.error('Erro ao carregar estatísticas:', e);
+        totalEl.textContent = pendEl.textContent =
+          andEl.textContent = resEl.textContent = 'Não disponível';
+      }
+
+      // Estatísticas por destinatário
+      try {
+        const porDest = (await API.getStatsByDestinatario()).data;
+        if (porDest.length === 0) {
+          const tr = document.createElement('tr');
+          const td = document.createElement('td');
+          td.colSpan = 5;
+          td.textContent = 'Sem dados disponíveis';
+          tr.appendChild(td);
+          tbody.appendChild(tr);
+        } else {
+          porDest.forEach(r => {
+            const tr = document.createElement('tr');
+
+            const destTd  = document.createElement('td');
+            destTd.textContent  = r.destinatario;
+            const totalTd = document.createElement('td');
+            totalTd.textContent = r.total;
+            const pendTd  = document.createElement('td');
+            pendTd.textContent  = r.pendente ?? '-';
+            const andTd   = document.createElement('td');
+            andTd.textContent   = r.em_andamento ?? '-';
+            const resTd   = document.createElement('td');
+            resTd.textContent   = r.resolvido ?? '-';
+
+            tr.appendChild(destTd);
+            tr.appendChild(totalTd);
+            tr.appendChild(pendTd);
+            tr.appendChild(andTd);
+            tr.appendChild(resTd);
+
+            tbody.appendChild(tr);
+          });
+        }
+      } catch (e) {
+        console.error('Erro ao carregar estatísticas por destinatário:', e);
+        tbody.innerHTML = '<tr><td colspan="5">Não foi possível carregar dados.</td></tr>';
       }
     });
   </script>


### PR DESCRIPTION
## Summary
- show `Não disponível` and a table message when stats API requests fail
- keep report rows empty when no data is returned

## Testing
- `npm test`
- loaded `/relatorios` and confirmed API stats populate
- simulated API failure to verify fallback text

------
https://chatgpt.com/codex/tasks/task_e_68b76f8ffcb08324a989703913225cda