### PR TITLE
refactor: externalize inline scripts

### DIFF
--- a/public/js/relatorios.js
+++ b/public/js/relatorios.js
@@ -1,0 +1,63 @@
+// public/js/relatorios.js
+// Código extraído de views/relatorios.ejs
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const totalEl = document.getElementById('relTotal');
+  const pendEl  = document.getElementById('relPendente');
+  const andEl   = document.getElementById('relAndamento');
+  const resEl   = document.getElementById('relResolvido');
+  const tbody   = document.getElementById('relPorDestinatario');
+
+  // Estatísticas gerais
+  try {
+    const stats = (await API.getStats()).data;
+    totalEl.textContent = stats.total;
+    pendEl.textContent  = stats.pendente;
+    andEl.textContent   = stats.em_andamento;
+    resEl.textContent   = stats.resolvido;
+  } catch (e) {
+    console.error('Erro ao carregar estatísticas:', e);
+    totalEl.textContent = pendEl.textContent =
+      andEl.textContent = resEl.textContent = 'Não disponível';
+  }
+
+  // Estatísticas por destinatário
+  try {
+    const porDest = (await API.getStatsByDestinatario()).data;
+    if (porDest.length === 0) {
+      const tr = document.createElement('tr');
+      const td = document.createElement('td');
+      td.colSpan = 5;
+      td.textContent = 'Sem dados disponíveis';
+      tr.appendChild(td);
+      tbody.appendChild(tr);
+    } else {
+      porDest.forEach(r => {
+        const tr = document.createElement('tr');
+
+        const destTd  = document.createElement('td');
+        destTd.textContent  = r.destinatario;
+        const totalTd = document.createElement('td');
+        totalTd.textContent = r.total;
+        const pendTd  = document.createElement('td');
+        pendTd.textContent  = r.pendente ?? '-';
+        const andTd   = document.createElement('td');
+        andTd.textContent   = r.em_andamento ?? '-';
+        const resTd   = document.createElement('td');
+        resTd.textContent   = r.resolvido ?? '-';
+
+        tr.appendChild(destTd);
+        tr.appendChild(totalTd);
+        tr.appendChild(pendTd);
+        tr.appendChild(andTd);
+        tr.appendChild(resTd);
+
+        tbody.appendChild(tr);
+      });
+    }
+  } catch (e) {
+    console.error('Erro ao carregar estatísticas por destinatário:', e);
+    tbody.innerHTML = '<tr><td colspan="5">Não foi possível carregar dados.</td></tr>';
+  }
+});
+

--- a/public/js/visualizar-recado.js
+++ b/public/js/visualizar-recado.js
@@ -1,0 +1,56 @@
+// public/js/visualizar-recado.js
+// Código extraído de views/visualizar-recado.ejs
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const id = location.pathname.split('/').pop();
+  const container = document.getElementById('detalhesRecado');
+  try {
+    const { data: recado } = await API.getRecado(id);
+    container.textContent = '';
+
+    const dados = [
+      ['Data/Hora:', `${recado.data_ligacao} ${recado.hora_ligacao}`],
+      ['Destinatário:', recado.destinatario],
+      ['Remetente:', recado.remetente_nome],
+      ['Telefone:', recado.remetente_telefone || '-'],
+      ['E-mail:', recado.remetente_email || '-'],
+      ['Horário de Retorno:', recado.horario_retorno || '-'],
+      ['Assunto:', recado.assunto],
+      ['Situação:', recado.situacao],
+      ['Observações:', recado.observacoes || '-']
+    ];
+
+    dados.forEach(([label, value]) => {
+      const p = document.createElement('p');
+      const strong = document.createElement('strong');
+      strong.textContent = label + ' ';
+      p.appendChild(strong);
+      p.append(document.createTextNode(value));
+      container.appendChild(p);
+    });
+
+    const actions = document.createElement('div');
+    actions.style.marginTop = '1rem';
+    const edit = document.createElement('a');
+    edit.href = `/editar-recado/${id}`;
+    edit.className = 'btn btn-primary';
+    edit.textContent = '✏️ Editar';
+    const back = document.createElement('a');
+    back.href = '/recados';
+    back.className = 'btn btn-outline';
+    back.textContent = 'Voltar';
+    actions.appendChild(edit);
+    actions.appendChild(back);
+    container.appendChild(actions);
+  } catch (e) {
+    const message =
+      e && typeof e.message === 'string' && e.message.includes('404')
+        ? 'Recado não encontrado.'
+        : 'Erro ao carregar recado.';
+    container.textContent = message;
+    if (typeof Toast !== 'undefined' && Toast.error) {
+      Toast.error(message);
+    }
+  }
+});
+

--- a/views/relatorios.ejs
+++ b/views/relatorios.ejs
@@ -55,68 +55,6 @@
   <script src="/js/utils.js" defer></script>
   <script src="/js/app.js" defer></script>
   <script src="/js/navbar.js" defer></script>
-
-
-  <script>
-    document.addEventListener('DOMContentLoaded', async () => {
-      const totalEl = document.getElementById('relTotal');
-      const pendEl  = document.getElementById('relPendente');
-      const andEl   = document.getElementById('relAndamento');
-      const resEl   = document.getElementById('relResolvido');
-      const tbody   = document.getElementById('relPorDestinatario');
-
-      // Estatísticas gerais
-      try {
-        const stats = (await API.getStats()).data;
-        totalEl.textContent = stats.total;
-        pendEl.textContent  = stats.pendente;
-        andEl.textContent   = stats.em_andamento;
-        resEl.textContent   = stats.resolvido;
-      } catch (e) {
-        console.error('Erro ao carregar estatísticas:', e);
-        totalEl.textContent = pendEl.textContent =
-          andEl.textContent = resEl.textContent = 'Não disponível';
-      }
-
-      // Estatísticas por destinatário
-      try {
-        const porDest = (await API.getStatsByDestinatario()).data;
-        if (porDest.length === 0) {
-          const tr = document.createElement('tr');
-          const td = document.createElement('td');
-          td.colSpan = 5;
-          td.textContent = 'Sem dados disponíveis';
-          tr.appendChild(td);
-          tbody.appendChild(tr);
-        } else {
-          porDest.forEach(r => {
-            const tr = document.createElement('tr');
-
-            const destTd  = document.createElement('td');
-            destTd.textContent  = r.destinatario;
-            const totalTd = document.createElement('td');
-            totalTd.textContent = r.total;
-            const pendTd  = document.createElement('td');
-            pendTd.textContent  = r.pendente ?? '-';
-            const andTd   = document.createElement('td');
-            andTd.textContent   = r.em_andamento ?? '-';
-            const resTd   = document.createElement('td');
-            resTd.textContent   = r.resolvido ?? '-';
-
-            tr.appendChild(destTd);
-            tr.appendChild(totalTd);
-            tr.appendChild(pendTd);
-            tr.appendChild(andTd);
-            tr.appendChild(resTd);
-
-            tbody.appendChild(tr);
-          });
-        }
-      } catch (e) {
-        console.error('Erro ao carregar estatísticas por destinatário:', e);
-        tbody.innerHTML = '<tr><td colspan="5">Não foi possível carregar dados.</td></tr>';
-      }
-    });
-  </script>
+  <script src="/js/relatorios.js" defer></script>
 </body>
 </html>

--- a/views/visualizar-recado.ejs
+++ b/views/visualizar-recado.ejs
@@ -21,60 +21,6 @@
   <script src="/js/utils.js" defer></script>
   <script src="/js/app.js" defer></script>
   <script src="/js/navbar.js" defer></script>
-
-  <script>
-    document.addEventListener('DOMContentLoaded', async () => {
-      const id = location.pathname.split('/').pop();
-      const container = document.getElementById('detalhesRecado');
-      try {
-        const { data: recado } = await API.getRecado(id);
-        container.textContent = '';
-
-        const dados = [
-          ['Data/Hora:', `${recado.data_ligacao} ${recado.hora_ligacao}`],
-          ['Destinatário:', recado.destinatario],
-          ['Remetente:', recado.remetente_nome],
-          ['Telefone:', recado.remetente_telefone || '-'],
-          ['E-mail:', recado.remetente_email || '-'],
-          ['Horário de Retorno:', recado.horario_retorno || '-'],
-          ['Assunto:', recado.assunto],
-          ['Situação:', recado.situacao],
-          ['Observações:', recado.observacoes || '-']
-        ];
-
-        dados.forEach(([label, value]) => {
-          const p = document.createElement('p');
-          const strong = document.createElement('strong');
-          strong.textContent = label + ' ';
-          p.appendChild(strong);
-          p.append(document.createTextNode(value));
-          container.appendChild(p);
-        });
-
-        const actions = document.createElement('div');
-        actions.style.marginTop = '1rem';
-        const edit = document.createElement('a');
-        edit.href = `/editar-recado/${id}`;
-        edit.className = 'btn btn-primary';
-        edit.textContent = '✏️ Editar';
-        const back = document.createElement('a');
-        back.href = '/recados';
-        back.className = 'btn btn-outline';
-        back.textContent = 'Voltar';
-        actions.appendChild(edit);
-        actions.appendChild(back);
-        container.appendChild(actions);
-      } catch (e) {
-          const message =
-            (e && typeof e.message === 'string' && e.message.includes('404'))
-              ? 'Recado não encontrado.'
-              : 'Erro ao carregar recado.';
-          container.textContent = message;
-          if (typeof Toast !== 'undefined' && Toast.error) {
-            Toast.error(message);
-          }
-      }
-    });
-  </script>
+  <script src="/js/visualizar-recado.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- move inline JavaScript from relatorios and visualizar-recado views into dedicated files
- reference new scripts from views while keeping CSP policy of `scriptSrc 'self'`

## Testing
- `npm test`
- `curl -s http://localhost:3000/relatorios | rg 'relatorios.js'`
- `curl -s http://localhost:3000/visualizar-recado/1 | rg 'visualizar-recado.js'`


------
https://chatgpt.com/codex/tasks/task_e_68b7786d03608324876aa86737cbc3a6