### PR TITLE
Validate call date/time fields and add form test

### DIFF
--- a/__tests__/novo-recado.test.js
+++ b/__tests__/novo-recado.test.js
@@ -1,0 +1,52 @@
+const { JSDOM } = require('jsdom');
+
+describe('Validação do formulário de novo recado', () => {
+  let alertMock;
+
+  beforeAll(() => {
+    const dom = new JSDOM('<!doctype html><html><body></body></html>', { url: 'http://localhost' });
+    global.window = dom.window;
+    global.document = dom.window.document;
+    global.navigator = dom.window.navigator;
+    global.FormData = dom.window.FormData;
+  });
+
+  afterAll(() => {
+    delete global.window;
+    delete global.document;
+    delete global.navigator;
+    delete global.FormData;
+    delete global.alert;
+  });
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <form id="formNovoRecado">
+        <input name="destinatario" value="Alice" />
+        <input name="remetente_nome" value="Bob" />
+        <input name="assunto" value="Teste" />
+        <input name="data_ligacao" value="" />
+        <input name="hora_ligacao" value="" />
+        <button type="submit">Salvar Recado</button>
+      </form>
+    `;
+
+    alertMock = jest.fn();
+    global.alert = alertMock;
+    window.alert = alertMock;
+
+    delete require.cache[require.resolve('../public/js/novo-recado.js')];
+    require('../public/js/novo-recado.js');
+    document.dispatchEvent(new window.Event('DOMContentLoaded'));
+  });
+
+  test('exibe mensagens específicas para data e hora ausentes', () => {
+    const form = document.getElementById('formNovoRecado');
+    form.dispatchEvent(new window.Event('submit', { bubbles: true, cancelable: true }));
+
+    expect(alertMock).toHaveBeenCalledTimes(1);
+    const message = alertMock.mock.calls[0][0];
+    expect(message).toContain('Data da ligação é obrigatória');
+    expect(message).toContain('Hora da ligação é obrigatória');
+  });
+});

--- a/public/js/novo-recado.js
+++ b/public/js/novo-recado.js
@@ -47,9 +47,21 @@ document.addEventListener('DOMContentLoaded', function () {
       }
       console.log('✅ Dados coletados:', data);
 
-      // Validação básica
-      if (!data.destinatario || !data.remetente_nome || !data.assunto) {
-        alert('Por favor, preencha todos os campos obrigatórios');
+      // Validação básica dos campos obrigatórios
+      const requiredFields = [
+        { key: 'destinatario', message: 'Destinatário é obrigatório.' },
+        { key: 'remetente_nome', message: 'Remetente é obrigatório.' },
+        { key: 'assunto', message: 'Assunto é obrigatório.' },
+        { key: 'data_ligacao', message: 'Data da ligação é obrigatória.' },
+        { key: 'hora_ligacao', message: 'Hora da ligação é obrigatória.' }
+      ];
+
+      const missing = requiredFields
+        .filter(field => !data[field.key])
+        .map(field => field.message);
+
+      if (missing.length > 0) {
+        alert(missing.join('\n'));
         return;
       }
 


### PR DESCRIPTION
## Summary
- validate call date and time fields in Novo Recado form and show per-field errors
- cover missing call fields with integration test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b77a42fc30832487cbf9703ab9b26c