### PR TITLE
Use upsert for admin seed migration

### DIFF
--- a/data/migrations/03_seed_admin.sql
+++ b/data/migrations/03_seed_admin.sql
@@ -1,2 +1,12 @@
-INSERT OR IGNORE INTO users (name, email, password_hash, role)
-VALUES ('Administrador', 'admin@example.com', '$argon2id$v=19$m=65536,t=3,p=4$hb6VPt5+tIAcPnRjUQLxjA$7/fPp0QrtYciDIddzeVsK7aqrGrEOV7tLIRX2VFa0S0', 'ADMIN');
+INSERT INTO users (name, email, password_hash, role, is_active)
+VALUES (
+    'Administrador',
+    'contato@amah.com.br',
+    '$argon2id$v=19$m=65536,t=3,p=1$dvcNSjbgcmcnvCgpIZPqTQ$S0EmFlqfFwCDM+xF5tzfYW2fxsx23Cl8udn3ywteOCE',
+    'ADMIN',
+    1
+)
+ON CONFLICT(email) DO UPDATE SET
+    name=excluded.name,
+    role=excluded.role,
+    is_active=excluded.is_active;


### PR DESCRIPTION
## Summary
- ensure admin seed uses upsert on email conflict
- seed admin with contato@amah.com.br and keep existing password

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68baedf40f3c8324aa5673b1c72c3319