### PR TITLE
feat: enhance user and recado models

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ remetente_telefone, remetente_email, horario_retorno
 
 assunto, situacao, observacoes
 
-criado_em, atualizado_em
+created_at, updated_at, created_by, updated_by
 
 Índices criados para performance:
 

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -16,9 +16,9 @@ exports.login = async (req, res) => {
     });
   }
 
-  const { username, password } = req.body;
-  const user = UserModel.findByUsername(username);
-  if (!user || !user.active) {
+  const { email, password } = req.body;
+  const user = UserModel.findByEmail(email);
+  if (!user || !user.is_active) {
     return res.status(401).render('login', {
       title: 'Login',
       csrfToken: req.csrfToken(),
@@ -27,7 +27,7 @@ exports.login = async (req, res) => {
   }
 
   try {
-    const valid = await argon2.verify(user.password, password, { type: argon2.argon2id });
+    const valid = await argon2.verify(user.password_hash, password, { type: argon2.argon2id });
     if (!valid) {
       return res.status(401).render('login', {
         title: 'Login',
@@ -35,7 +35,7 @@ exports.login = async (req, res) => {
         error: 'Credenciais inválidas'
       });
     }
-    req.session.user = { id: user.id, username: user.username, role: user.role };
+    req.session.user = { id: user.id, name: user.name, email: user.email, role: user.role };
     res.redirect('/');
   } catch (err) {
     console.error('Erro ao verificar senha:', err);

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -3,8 +3,11 @@ const argon2 = require('argon2');
 const UserModel = require('../models/user');
 
 exports.list = (req, res) => {
-  const users = UserModel.findAll();
-  res.json({ success: true, data: users });
+  const page  = Number(req.query.page) || 1;
+  const limit = Number(req.query.limit) || 10;
+  const q     = req.query.q || '';
+  const result = UserModel.list({ q, page, limit });
+  res.json({ success: true, data: result.data, pagination: result.pagination });
 };
 
 exports.create = async (req, res) => {
@@ -12,9 +15,9 @@ exports.create = async (req, res) => {
   if (!errors.isEmpty()) {
     return res.status(400).json({ success: false, errors: errors.array() });
   }
-  const { username, password, role } = req.body;
+  const { name, email, password, role } = req.body;
   const hash = await argon2.hash(password, { type: argon2.argon2id });
-  const user = UserModel.create({ username, password: hash, role });
+  const user = UserModel.create({ name, email, password_hash: hash, role });
   res.status(201).json({ success: true, data: user });
 };
 

--- a/data/migrations/04_recados_auth.sql
+++ b/data/migrations/04_recados_auth.sql
@@ -10,12 +10,14 @@ CREATE TABLE IF NOT EXISTS recados (
     assunto TEXT NOT NULL,
     situacao VARCHAR(20) DEFAULT 'pendente' CHECK (situacao IN ('pendente','em_andamento','resolvido')),
     observacoes TEXT,
-    criado_em DATETIME DEFAULT CURRENT_TIMESTAMP,
-    atualizado_em DATETIME DEFAULT CURRENT_TIMESTAMP
+    created_by INTEGER REFERENCES users(id),
+    updated_by INTEGER REFERENCES users(id),
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE INDEX IF NOT EXISTS idx_data_ligacao ON recados(data_ligacao);
 CREATE INDEX IF NOT EXISTS idx_destinatario ON recados(destinatario);
 CREATE INDEX IF NOT EXISTS idx_situacao ON recados(situacao);
 CREATE INDEX IF NOT EXISTS idx_remetente_nome ON recados(remetente_nome);
-CREATE INDEX IF NOT EXISTS idx_criado_em ON recados(criado_em);
+CREATE INDEX IF NOT EXISTS idx_created_at ON recados(created_at);

--- a/design_sistema.md
+++ b/design_sistema.md
@@ -25,8 +25,10 @@ CREATE TABLE recados (
     assunto TEXT NOT NULL,
     situacao ENUM('pendente', 'em_andamento', 'resolvido') DEFAULT 'pendente',
     observacoes TEXT,
-    criado_em DATETIME DEFAULT CURRENT_TIMESTAMP,
-    atualizado_em DATETIME DEFAULT CURRENT_TIMESTAMP
+    created_by INTEGER REFERENCES users(id),
+    updated_by INTEGER REFERENCES users(id),
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
 );
 ```
 
@@ -36,6 +38,7 @@ CREATE INDEX idx_data_ligacao ON recados(data_ligacao);
 CREATE INDEX idx_destinatario ON recados(destinatario);
 CREATE INDEX idx_situacao ON recados(situacao);
 CREATE INDEX idx_remetente_nome ON recados(remetente_nome);
+CREATE INDEX idx_created_at ON recados(created_at);
 ```
 
 ## API Endpoints

--- a/middleware/validation.js
+++ b/middleware/validation.js
@@ -1,6 +1,6 @@
 const { body, query, param, validationResult } = require('express-validator');
 const ALLOWED_STATUS    = ['pendente','em_andamento','resolvido'];
-const ALLOWED_ORDER_BY  = ['criado_em','data_ligacao','situacao'];
+const ALLOWED_ORDER_BY  = ['created_at','updated_at','data_ligacao','situacao'];
 const ALLOWED_ORDER_DIR = ['ASC','DESC'];
 
 // Middleware para verificar erros de validação

--- a/migrations/schema_20250718.sql
+++ b/migrations/schema_20250718.sql
@@ -1,21 +1,35 @@
+CREATE TABLE users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    email TEXT NOT NULL UNIQUE,
+    password_hash TEXT NOT NULL,
+    role TEXT NOT NULL DEFAULT 'OPERADOR' CHECK (role IN ('ADMIN','SUPERVISOR','OPERADOR','LEITOR')),
+    is_active INTEGER NOT NULL DEFAULT 1,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
 CREATE TABLE recados (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                data_ligacao DATE NOT NULL,
-                hora_ligacao TIME NOT NULL,
-                destinatario VARCHAR(255) NOT NULL,
-                remetente_nome VARCHAR(255) NOT NULL,
-                remetente_telefone VARCHAR(20),
-                remetente_email VARCHAR(255),
-                horario_retorno VARCHAR(100),
-                assunto TEXT NOT NULL,
-                situacao VARCHAR(20) DEFAULT 'pendente' CHECK (situacao IN ('pendente', 'em_andamento', 'resolvido')),
-                observacoes TEXT,
-                criado_em DATETIME DEFAULT CURRENT_TIMESTAMP,
-                atualizado_em DATETIME DEFAULT CURRENT_TIMESTAMP
-            );
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    data_ligacao DATE NOT NULL,
+    hora_ligacao TIME NOT NULL,
+    destinatario VARCHAR(255) NOT NULL,
+    remetente_nome VARCHAR(255) NOT NULL,
+    remetente_telefone VARCHAR(20),
+    remetente_email VARCHAR(255),
+    horario_retorno VARCHAR(100),
+    assunto TEXT NOT NULL,
+    situacao VARCHAR(20) DEFAULT 'pendente' CHECK (situacao IN ('pendente', 'em_andamento', 'resolvido')),
+    observacoes TEXT,
+    created_by INTEGER REFERENCES users(id),
+    updated_by INTEGER REFERENCES users(id),
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
 CREATE TABLE sqlite_sequence(name,seq);
 CREATE INDEX idx_data_ligacao ON recados(data_ligacao);
 CREATE INDEX idx_destinatario ON recados(destinatario);
 CREATE INDEX idx_situacao ON recados(situacao);
 CREATE INDEX idx_remetente_nome ON recados(remetente_nome);
-CREATE INDEX idx_criado_em ON recados(criado_em);
+CREATE INDEX idx_created_at ON recados(created_at);

--- a/models/recado.js
+++ b/models/recado.js
@@ -1,246 +1,266 @@
 const dbManager = require('../config/database');
 
 class RecadoModel {
-    constructor() {
-        this.db = dbManager.getDatabase();
-        this.allowedOrderBy = [
-            'id',
-            'data_ligacao',
-            'hora_ligacao',
-            'destinatario',
-            'remetente_nome',
-            'situacao',
-            'criado_em',
-            'atualizado_em'
-        ];
-        this.allowedOrderDir = ['ASC', 'DESC'];
+  constructor() {
+    this.db = dbManager.getDatabase();
+    this.allowedOrderBy = [
+      'id',
+      'data_ligacao',
+      'hora_ligacao',
+      'destinatario',
+      'remetente_nome',
+      'situacao',
+      'created_at',
+      'updated_at'
+    ];
+    this.allowedOrderDir = ['ASC', 'DESC'];
+  }
+
+  _ensureDb() {
+    if (!this.db || !this.db.open) {
+      throw new Error('Database connection is not initialized');
+    }
+  }
+
+  _buildFilterQuery(filters = {}) {
+    let clause = '';
+    const params = [];
+
+    if (filters.data_inicio) {
+      clause += ' AND data_ligacao >= ?';
+      params.push(filters.data_inicio);
+    }
+    if (filters.data_fim) {
+      clause += ' AND data_ligacao <= ?';
+      params.push(filters.data_fim);
     }
 
-    _ensureDb() {
-        if (!this.db || !this.db.open) {
-            throw new Error('Database connection is not initialized');
-        }
+    if (filters.destinatario) {
+      clause += ' AND destinatario LIKE ?';
+      params.push(`%${filters.destinatario}%`);
     }
 
-    // Helper para construir filtros reutilizáveis
-    _buildFilterQuery(filters = {}) {
-        let clause = '';
-        const params = [];
-
-        // Filtro por data
-        if (filters.data_inicio) {
-            clause += ' AND data_ligacao >= ?';
-            params.push(filters.data_inicio);
-        }
-        if (filters.data_fim) {
-            clause += ' AND data_ligacao <= ?';
-            params.push(filters.data_fim);
-        }
-
-        // Filtro por destinatário
-        if (filters.destinatario) {
-            clause += ' AND destinatario LIKE ?';
-            params.push(`%${filters.destinatario}%`);
-        }
-
-        // Filtro por situação
-        if (filters.situacao) {
-            clause += ' AND situacao = ?';
-            params.push(filters.situacao);
-        }
-
-        // Filtro por remetente
-        if (filters.remetente) {
-            clause += ' AND remetente_nome LIKE ?';
-            params.push(`%${filters.remetente}%`);
-        }
-
-        // Busca geral
-        if (filters.busca) {
-            clause += ` AND (
-                remetente_nome LIKE ? OR
-                destinatario LIKE ? OR
-                assunto LIKE ? OR
-                observacoes LIKE ?
-            )`;
-            const searchTerm = `%${filters.busca}%`;
-            params.push(searchTerm, searchTerm, searchTerm, searchTerm);
-        }
-
-        return { clause, params };
+    if (filters.situacao) {
+      clause += ' AND situacao = ?';
+      params.push(filters.situacao);
     }
 
-    // Criar novo recado
-    create(recadoData) {
-        this._ensureDb();
-        const stmt = this.db.prepare(`
-            INSERT INTO recados (
-                data_ligacao, hora_ligacao, destinatario, remetente_nome,
-                remetente_telefone, remetente_email, horario_retorno,
-                assunto, situacao, observacoes
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        `);
-
-        const result = stmt.run(
-            recadoData.data_ligacao,
-            recadoData.hora_ligacao,
-            recadoData.destinatario,
-            recadoData.remetente_nome,
-            recadoData.remetente_telefone || null,
-            recadoData.remetente_email || null,
-            recadoData.horario_retorno || null,
-            recadoData.assunto,
-            recadoData.situacao || 'pendente',
-            recadoData.observacoes || null
-        );
-
-        return this.findById(result.lastInsertRowid);
+    if (filters.remetente) {
+      clause += ' AND remetente_nome LIKE ?';
+      params.push(`%${filters.remetente}%`);
     }
 
-    // Buscar por ID
-    findById(id) {
-        this._ensureDb();
-        const stmt = this.db.prepare('SELECT * FROM recados WHERE id = ?');
-        return stmt.get(id);
+    if (filters.created_by || filters.user_id || filters.userId) {
+      const user = filters.created_by || filters.user_id || filters.userId;
+      clause += ' AND created_by = ?';
+      params.push(user);
     }
 
-    // Listar todos com filtros
-    findAll(filters = {}) {
-        this._ensureDb();
-        const { clause, params } = this._buildFilterQuery(filters);
-        let query = `SELECT * FROM recados WHERE 1=1${clause}`;
-
-        // Ordenação
-        const orderBy = this.allowedOrderBy.includes(filters.orderBy)
-            ? filters.orderBy
-            : 'criado_em';
-        const dir = (filters.orderDir || '').toUpperCase();
-        const orderDir = this.allowedOrderDir.includes(dir) ? dir : 'DESC';
-        query += ` ORDER BY ${orderBy} ${orderDir}`;
-
-        // Paginação
-        if (filters.limit) {
-            query += ' LIMIT ?';
-            params.push(parseInt(filters.limit));
-            if (filters.offset) {
-                query += ' OFFSET ?';
-                params.push(parseInt(filters.offset));
-            }
-        }
-
-        const stmt = this.db.prepare(query);
-        return stmt.all(...params);
+    if (filters.busca) {
+      clause += ` AND (
+        remetente_nome LIKE ? OR
+        destinatario LIKE ? OR
+        assunto LIKE ? OR
+        observacoes LIKE ?
+      )`;
+      const searchTerm = `%${filters.busca}%`;
+      params.push(searchTerm, searchTerm, searchTerm, searchTerm);
     }
 
-    // Contar registros com filtros
-    // Este método pode não existir em versões antigas do sistema. Caso
-    // necessite adicionar suporte à contagem de registros, implemente aqui.
-    count(filters = {}) {
-        this._ensureDb();
-        const { clause, params } = this._buildFilterQuery(filters);
-        const query = `SELECT COUNT(*) as total FROM recados WHERE 1=1${clause}`;
-        const stmt = this.db.prepare(query);
-        const row = stmt.get(...params);
-        return row ? row.total : 0;
+    return { clause, params };
+  }
+
+  create(recadoData) {
+    this._ensureDb();
+    const creator = recadoData.created_by || recadoData.user_id || recadoData.userId || null;
+    const updater = recadoData.updated_by || creator;
+    const stmt = this.db.prepare(`
+      INSERT INTO recados (
+        data_ligacao, hora_ligacao, destinatario, remetente_nome,
+        remetente_telefone, remetente_email, horario_retorno,
+        assunto, situacao, observacoes, created_by, updated_by
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+    const result = stmt.run(
+      recadoData.data_ligacao,
+      recadoData.hora_ligacao,
+      recadoData.destinatario,
+      recadoData.remetente_nome,
+      recadoData.remetente_telefone || null,
+      recadoData.remetente_email || null,
+      recadoData.horario_retorno || null,
+      recadoData.assunto,
+      recadoData.situacao || 'pendente',
+      recadoData.observacoes || null,
+      creator,
+      updater
+    );
+    return this.findById(result.lastInsertRowid);
+  }
+
+  findById(id) {
+    this._ensureDb();
+    const stmt = this.db.prepare('SELECT * FROM recados WHERE id = ?');
+    return stmt.get(id);
+  }
+
+  findAll(filters = {}) {
+    this._ensureDb();
+    const { clause, params } = this._buildFilterQuery(filters);
+    let query = `SELECT * FROM recados WHERE 1=1${clause}`;
+    const orderBy = this.allowedOrderBy.includes(filters.orderBy)
+      ? filters.orderBy
+      : 'created_at';
+    const dir = (filters.orderDir || '').toUpperCase();
+    const orderDir = this.allowedOrderDir.includes(dir) ? dir : 'DESC';
+    query += ` ORDER BY ${orderBy} ${orderDir}`;
+    if (filters.limit) {
+      query += ' LIMIT ?';
+      params.push(parseInt(filters.limit));
+      if (filters.offset) {
+        query += ' OFFSET ?';
+        params.push(parseInt(filters.offset));
+      }
     }
+    const stmt = this.db.prepare(query);
+    return stmt.all(...params);
+  }
 
-    // Atualizar recado
-    update(id, recadoData) {
-        this._ensureDb();
-        const stmt = this.db.prepare(`
-            UPDATE recados SET
-                data_ligacao = ?, hora_ligacao = ?, destinatario = ?,
-                remetente_nome = ?, remetente_telefone = ?, remetente_email = ?,
-                horario_retorno = ?, assunto = ?, situacao = ?, observacoes = ?,
-                atualizado_em = CURRENT_TIMESTAMP
-            WHERE id = ?
-        `);
+  count(filters = {}) {
+    this._ensureDb();
+    const { clause, params } = this._buildFilterQuery(filters);
+    const query = `SELECT COUNT(*) as total FROM recados WHERE 1=1${clause}`;
+    const stmt = this.db.prepare(query);
+    const row = stmt.get(...params);
+    return row ? row.total : 0;
+  }
 
-        const result = stmt.run(
-            recadoData.data_ligacao,
-            recadoData.hora_ligacao,
-            recadoData.destinatario,
-            recadoData.remetente_nome,
-            recadoData.remetente_telefone || null,
-            recadoData.remetente_email || null,
-            recadoData.horario_retorno || null,
-            recadoData.assunto,
-            recadoData.situacao,
-            recadoData.observacoes || null,
-            id
-        );
+  update(id, recadoData) {
+    this._ensureDb();
+    const updater = recadoData.updated_by || recadoData.user_id || recadoData.userId || null;
+    const stmt = this.db.prepare(`
+      UPDATE recados SET
+        data_ligacao = ?, hora_ligacao = ?, destinatario = ?,
+        remetente_nome = ?, remetente_telefone = ?, remetente_email = ?,
+        horario_retorno = ?, assunto = ?, situacao = ?, observacoes = ?,
+        updated_at = CURRENT_TIMESTAMP, updated_by = ?
+      WHERE id = ?
+    `);
+    const result = stmt.run(
+      recadoData.data_ligacao,
+      recadoData.hora_ligacao,
+      recadoData.destinatario,
+      recadoData.remetente_nome,
+      recadoData.remetente_telefone || null,
+      recadoData.remetente_email || null,
+      recadoData.horario_retorno || null,
+      recadoData.assunto,
+      recadoData.situacao,
+      recadoData.observacoes || null,
+      updater,
+      id
+    );
+    return result.changes > 0 ? this.findById(id) : null;
+  }
 
-        return result.changes > 0 ? this.findById(id) : null;
-    }
+  updateSituacao(id, situacao, userId = null) {
+    this._ensureDb();
+    const stmt = this.db.prepare(`
+      UPDATE recados SET
+        situacao = ?,
+        updated_at = CURRENT_TIMESTAMP,
+        updated_by = ?
+      WHERE id = ?
+    `);
+    const result = stmt.run(situacao, userId, id);
+    return result.changes > 0;
+  }
 
-    // Atualizar apenas situação
-    updateSituacao(id, situacao) {
-        this._ensureDb();
-        const stmt = this.db.prepare(`
-            UPDATE recados SET
-                situacao = ?,
-                atualizado_em = CURRENT_TIMESTAMP
-            WHERE id = ?
-        `);
-        const result = stmt.run(situacao, id);
-        return result.changes > 0;
-    }
+  delete(id) {
+    this._ensureDb();
+    const stmt = this.db.prepare('DELETE FROM recados WHERE id = ?');
+    const result = stmt.run(id);
+    return result.changes > 0;
+  }
 
-    // Excluir recado
-    delete(id) {
-        this._ensureDb();
-        const stmt = this.db.prepare('DELETE FROM recados WHERE id = ?');
-        const result = stmt.run(id);
-        return result.changes > 0;
-    }
+  getStats() {
+    this._ensureDb();
+    const stmt = this.db.prepare(`
+      SELECT
+        COUNT(*) AS total,
+        SUM(CASE WHEN situacao = 'pendente' THEN 1 ELSE 0 END)      AS pendente,
+        SUM(CASE WHEN situacao = 'em_andamento' THEN 1 ELSE 0 END) AS em_andamento,
+        SUM(CASE WHEN situacao = 'resolvido' THEN 1 ELSE 0 END)    AS resolvido
+      FROM recados
+    `);
+    const row = stmt.get();
+    return {
+      total: row.total,
+      pendente: row.pendente,
+      em_andamento: row.em_andamento,
+      resolvido: row.resolvido,
+    };
+  }
 
-    // Estatísticas
-    getStats() {
-        this._ensureDb();
-        const stmt = this.db.prepare(`
-            SELECT
-                COUNT(*) AS total,
-                SUM(CASE WHEN situacao = 'pendente' THEN 1 ELSE 0 END)      AS pendente,
-                SUM(CASE WHEN situacao = 'em_andamento' THEN 1 ELSE 0 END) AS em_andamento,
-                SUM(CASE WHEN situacao = 'resolvido' THEN 1 ELSE 0 END)    AS resolvido
-            FROM recados
-        `);
-        const row = stmt.get();
-        return {
-            total:        row.total,
-            pendente:     row.pendente,
-            em_andamento: row.em_andamento,
-            resolvido:    row.resolvido,
-        };
-    }
+  getStatsByDestinatario() {
+    this._ensureDb();
+    const stmt = this.db.prepare(`
+      SELECT
+        destinatario,
+        COUNT(*) AS total,
+        SUM(CASE WHEN situacao = 'pendente' THEN 1 ELSE 0 END)      AS pendente,
+        SUM(CASE WHEN situacao = 'em_andamento' THEN 1 ELSE 0 END) AS em_andamento,
+        SUM(CASE WHEN situacao = 'resolvido' THEN 1 ELSE 0 END)    AS resolvido
+      FROM recados
+      GROUP BY destinatario
+      ORDER BY total DESC
+    `);
+    return stmt.all();
+  }
 
-    // Estatísticas agrupadas por destinatário
-    getStatsByDestinatario() {
-        this._ensureDb();
-        const stmt = this.db.prepare(`
-            SELECT
-                destinatario,
-                COUNT(*) AS total,
-                SUM(CASE WHEN situacao = 'pendente' THEN 1 ELSE 0 END)      AS pendente,
-                SUM(CASE WHEN situacao = 'em_andamento' THEN 1 ELSE 0 END) AS em_andamento,
-                SUM(CASE WHEN situacao = 'resolvido' THEN 1 ELSE 0 END)    AS resolvido
-            FROM recados
-            GROUP BY destinatario
-            ORDER BY total DESC
-        `);
-        return stmt.all();
-    }
+  reportByMonth() {
+    this._ensureDb();
+    const stmt = this.db.prepare(`
+      SELECT strftime('%Y-%m', data_ligacao) AS month, COUNT(*) AS total
+      FROM recados
+      GROUP BY month
+      ORDER BY month
+    `);
+    return stmt.all();
+  }
 
-    // Últimos N recados
-    getRecentes(limit = 10) {
-        this._ensureDb();
-        const stmt = this.db.prepare(`
-            SELECT * FROM recados
-            ORDER BY criado_em DESC
-            LIMIT ?
-        `);
-        return stmt.all(limit);
-    }
+  reportByStatus() {
+    this._ensureDb();
+    const stmt = this.db.prepare(`
+      SELECT situacao AS status, COUNT(*) AS total
+      FROM recados
+      GROUP BY situacao
+      ORDER BY status
+    `);
+    return stmt.all();
+  }
+
+  reportByResponsavel() {
+    this._ensureDb();
+    const stmt = this.db.prepare(`
+      SELECT u.id AS user_id, u.name, u.email, COUNT(r.id) AS total
+      FROM recados r
+      JOIN users u ON r.created_by = u.id
+      GROUP BY r.created_by
+      ORDER BY total DESC
+    `);
+    return stmt.all();
+  }
+
+  getRecentes(limit = 10) {
+    this._ensureDb();
+    const stmt = this.db.prepare(`
+      SELECT * FROM recados
+      ORDER BY created_at DESC
+      LIMIT ?
+    `);
+    return stmt.all(limit);
+  }
 }
 
 module.exports = new RecadoModel();

--- a/models/user.js
+++ b/models/user.js
@@ -7,37 +7,88 @@ class UserModel {
   }
 
   _init() {
-    if (!this.db || !this.db.open) {
-      throw new Error('Database connection is not initialized');
-    }
+    this._ensureDb();
     this.db.prepare(`CREATE TABLE IF NOT EXISTS users (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
-      username TEXT UNIQUE NOT NULL,
-      password TEXT NOT NULL,
-      role TEXT NOT NULL DEFAULT 'USER',
-      active INTEGER NOT NULL DEFAULT 1,
-      criado_em DATETIME DEFAULT CURRENT_TIMESTAMP
+      name TEXT NOT NULL,
+      email TEXT NOT NULL UNIQUE,
+      password_hash TEXT NOT NULL,
+      role TEXT NOT NULL DEFAULT 'OPERADOR' CHECK (role IN ('ADMIN','SUPERVISOR','OPERADOR','LEITOR')),
+      is_active INTEGER NOT NULL DEFAULT 1,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
     )`).run();
   }
 
-  findByUsername(username) {
-    const stmt = this.db.prepare('SELECT * FROM users WHERE username = ?');
-    return stmt.get(username);
+  _ensureDb() {
+    if (!this.db || !this.db.open) {
+      throw new Error('Database connection is not initialized');
+    }
   }
 
-  findAll() {
-    const stmt = this.db.prepare('SELECT id, username, role, active FROM users');
-    return stmt.all();
+  findByEmail(email) {
+    this._ensureDb();
+    const stmt = this.db.prepare('SELECT * FROM users WHERE email = ?');
+    return stmt.get(email);
   }
 
   create(user) {
-    const stmt = this.db.prepare('INSERT INTO users (username, password, role, active) VALUES (?, ?, ?, 1)');
-    const result = stmt.run(user.username, user.password, user.role || 'USER');
-    return { id: result.lastInsertRowid, username: user.username, role: user.role || 'USER', active: 1 };
+    this._ensureDb();
+    const stmt = this.db.prepare(`
+      INSERT INTO users (name, email, password_hash, role, is_active)
+      VALUES (?, ?, ?, ?, 1)
+    `);
+    const result = stmt.run(
+      user.name,
+      user.email,
+      user.password_hash,
+      user.role || 'OPERADOR'
+    );
+    return {
+      id: result.lastInsertRowid,
+      name: user.name,
+      email: user.email,
+      role: user.role || 'OPERADOR',
+      is_active: 1,
+    };
+  }
+
+  list({ q = '', page = 1, limit = 10 } = {}) {
+    this._ensureDb();
+    const offset = (page - 1) * limit;
+    const params = [];
+    let where = '';
+    if (q) {
+      where = 'WHERE name LIKE ? OR email LIKE ?';
+      const term = `%${q}%`;
+      params.push(term, term);
+    }
+    const dataStmt = this.db.prepare(`
+      SELECT id, name, email, role, is_active, created_at, updated_at
+      FROM users
+      ${where}
+      ORDER BY name ASC
+      LIMIT ? OFFSET ?
+    `);
+    const data = dataStmt.all(...params, limit, offset);
+    const countStmt = this.db.prepare(`SELECT COUNT(*) as total FROM users ${where}`);
+    const { total } = countStmt.get(...params);
+    return {
+      data,
+      pagination: {
+        total,
+        page,
+        limit,
+        pages: Math.ceil(total / limit)
+      }
+    };
   }
 
   setActive(id, active) {
-    const stmt = this.db.prepare('UPDATE users SET active = ? WHERE id = ?');
+    this._ensureDb();
+    const stmt = this.db.prepare(
+      'UPDATE users SET is_active = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?'
+    );
     const result = stmt.run(active ? 1 : 0, id);
     return result.changes > 0;
   }

--- a/routes/api.js
+++ b/routes/api.js
@@ -177,6 +177,30 @@ router.get('/stats/por-destinatario', wrap((_, res) => {
 }));
 
 // ───────────────────────────────────────────────────────────
+// GET /api/stats/por-mes – estatísticas agrupadas por mês
+// ───────────────────────────────────────────────────────────
+router.get('/stats/por-mes', wrap((_, res) => {
+  const data = RecadoModel.reportByMonth();
+  res.json({ success: true, data });
+}));
+
+// ───────────────────────────────────────────────────────────
+// GET /api/stats/por-status – estatísticas agrupadas por status
+// ───────────────────────────────────────────────────────────
+router.get('/stats/por-status', wrap((_, res) => {
+  const data = RecadoModel.reportByStatus();
+  res.json({ success: true, data });
+}));
+
+// ───────────────────────────────────────────────────────────
+// GET /api/stats/por-responsavel – estatísticas por usuário responsável
+// ───────────────────────────────────────────────────────────
+router.get('/stats/por-responsavel', wrap((_, res) => {
+  const data = RecadoModel.reportByResponsavel();
+  res.json({ success: true, data });
+}));
+
+// ───────────────────────────────────────────────────────────
 // GET /api/recados-recentes – últimos N recados (default 10)
 // ───────────────────────────────────────────────────────────
 router.get('/recados-recentes', wrap((req, res) => {


### PR DESCRIPTION
## Summary
- add comprehensive UserModel with findByEmail, create, list and activation handling
- extend RecadoModel with audit fields, user filtering and reporting helpers
- update SQL schema, validations and controllers for new user and recado structure

## Testing
- `npm test` *(fails: GET /api/recados lists with filters and pagination expected 200 Received 400)*

------
https://chatgpt.com/codex/tasks/task_e_68baf7437830832480ffbd1d0b045edb