### PR TITLE
Ensure navbar renders without user and propagate session user

### DIFF
--- a/routes/web.js
+++ b/routes/web.js
@@ -43,43 +43,45 @@ router.post(
 
 // Dashboard
 router.get('/', requireAuth, (req, res) => {
-  res.render('index', { title: 'Dashboard' });
+  res.render('index', { title: 'Dashboard', user: req.session.user || null });
 });
 
 // Lista de recados
 router.get('/recados', requireAuth, (req, res) => {
-  res.render('recados', { title: 'Recados' });
+  res.render('recados', { title: 'Recados', user: req.session.user || null });
 });
 
 // Novo recado
 router.get('/novo-recado', requireAuth, (req, res) => {
-  res.render('novo-recado', { title: 'Novo Recado' });
+  res.render('novo-recado', { title: 'Novo Recado', user: req.session.user || null });
 });
 
 // Editar recado
 router.get('/editar-recado/:id', requireAuth, (req, res) => {
   res.render('editar-recado', {
-    title: 'Editar Recado',
-    id: req.params.id
-  });
+      title: 'Editar Recado',
+      id: req.params.id,
+      user: req.session.user || null
+    });
 });
 
 // Visualizar recado
 router.get('/visualizar-recado/:id', requireAuth, (req, res) => {
   res.render('visualizar-recado', {
-    title: 'Visualizar Recado',
-    id: req.params.id
-  });
+      title: 'Visualizar Recado',
+      id: req.params.id,
+      user: req.session.user || null
+    });
 });
 
 // Relatórios
 router.get('/relatorios', requireAuth, requireRole('ADMIN'), (req, res) => {
-  res.render('relatorios', { title: 'Relatórios' });
+  res.render('relatorios', { title: 'Relatórios', user: req.session.user || null });
 });
 
 // 404
 router.use((req, res) => {
-  res.status(404).render('404', { title: 'Página não encontrada' });
+  res.status(404).render('404', { title: 'Página não encontrada', user: req.session.user || null });
 });
 
 module.exports = router;

--- a/views/partials/navbar.ejs
+++ b/views/partials/navbar.ejs
@@ -11,13 +11,13 @@
         <li class="nav-item"><a class="nav-link<%= title === 'Dashboard' ? ' active' : '' %>" href="/">Dashboard</a></li>
         <li class="nav-item"><a class="nav-link<%= title === 'Recados' ? ' active' : '' %>" href="/recados">Recados</a></li>
         <li class="nav-item"><a class="nav-link<%= title === 'Novo Recado' ? ' active' : '' %>" href="/novo-recado">Novo Recado</a></li>
-        <% if (user && user.role === 'ADMIN') { %>
+        <% if (typeof user !== 'undefined' && user && user.role === 'ADMIN') { %>
           <li class="nav-item"><a class="nav-link<%= title === 'Relatórios' ? ' active' : '' %>" href="/relatorios">Relatórios</a></li>
           <li class="nav-item"><a class="nav-link<%= title === 'Registrar Usuário' ? ' active' : '' %>" href="/register">Registrar</a></li>
         <% } %>
       </ul>
       <ul class="navbar-nav mb-2 mb-lg-0">
-        <% if (user) { %>
+        <% if (typeof user !== 'undefined' && user) { %>
           <li class="nav-item"><a class="nav-link" href="/logout">Sair</a></li>
         <% } else { %>
           <li class="nav-item"><a class="nav-link<%= title === 'Login' ? ' active' : '' %>" href="/login">Login</a></li>


### PR DESCRIPTION
## Summary
- Guard navbar's admin and logout links when `user` is undefined
- Pass `req.session.user` to all page renders

## Testing
- `npm test`
- `curl -i http://localhost:3000/login`
- `curl -i http://localhost:3000/`


------
https://chatgpt.com/codex/tasks/task_e_68bb6a1f35a883249e5f190e1e783ded