### PR TITLE
feat: make session SameSite configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Environment variable examples for LATE
+# Secret used to sign the session ID cookie
+SESSION_SECRET=your_session_secret
+# SameSite attribute for session cookies (lax, strict, or none)
+SAMESITE=lax

--- a/server.js
+++ b/server.js
@@ -27,7 +27,10 @@ try {
 
 // Inicializar aplicação Express
 const app = express();
-app.set('trust proxy', 1);
+// Trust first proxy when running behind a reverse proxy
+if (process.env.NODE_ENV === 'production') {
+  app.set('trust proxy', 1);
+}
 const PORT = process.env.PORT || 3000;
 
 // Define o caminho do CSS baseado no ambiente
@@ -99,7 +102,7 @@ app.use(
     cookie: {
       secure: true,
       httpOnly: true,
-      sameSite: 'lax'
+      sameSite: process.env.SAMESITE || 'lax'
     }
   })
 );


### PR DESCRIPTION
## Summary
- read SameSite attribute for session cookies from `SAMESITE` env variable
- document `SESSION_SECRET` and `SAMESITE` in `.env.example`
- trust first proxy in production to support secure cookies behind reverse proxies

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc4020d1cc8324b5dc1285b1b734c8