### PR TITLE
Add env example and Auth+CORS documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,10 @@
 # Environment variable examples for LATE
-# Secret used to sign the session ID cookie
-SESSION_SECRET=your_session_secret
-# SameSite attribute for session cookies (lax, strict, or none)
-SAMESITE=lax
+# Allowed origins for CORS (comma-separated)
+CORS_ORIGINS=https://late.miahchat.com,https://www.late.miahchat.com
+
+# Session secret for signing cookies
+SESSION_SECRET=CHANGE_THIS
+
+# Cookie SameSite policy
+# Use 'none' for cross-site usage (requires HTTPS)
+SAMESITE=none

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ git clone <repo>
 cd late
 npm install
 # Defina os domínios permitidos no CORS
-export ALLOWED_ORIGINS=http://localhost:3000,http://localhost:8080
+export CORS_ORIGINS=http://localhost:3000,http://localhost:8080
 npm start
 Acesse: http://localhost:3000 ou http://<SEU-IP>:3000
 
@@ -101,6 +101,38 @@ Produção com PM2
 pm2 start server.js --name "late"
 pm2 save
 pm2 startup
+
+## 🔐 Auth + CORS
+
+Exemplos de requisições utilizando CORS e autenticação de sessão:
+
+### Preflight
+
+```bash
+curl -i -X OPTIONS https://late.miahchat.com/login \
+  -H "Origin: https://late.miahchat.com" \
+  -H "Access-Control-Request-Method: POST" \
+  -H "Access-Control-Request-Headers: Content-Type"
+```
+
+### Login
+
+```bash
+curl -i -X POST https://late.miahchat.com/login \
+  -H "Origin: https://late.miahchat.com" \
+  -H "Content-Type: application/json" \
+  -c cookies.txt \
+  -d '{"username":"usuario","password":"senha"}'
+```
+
+### Requisição autenticada
+
+```bash
+curl -i https://late.miahchat.com/ \
+  -H "Origin: https://late.miahchat.com" \
+  -b cookies.txt
+```
+
 🔧 API REST
 Principais endpoints:
 


### PR DESCRIPTION
## Summary
- provide `.env.example` with CORS origins, session secret and SameSite guidance
- document CORS preflight, login and authenticated requests in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc43934e588324b7d45a8a9e613f64