### PR TITLE
Ensure login requests send credentials

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -3,7 +3,14 @@ const argon2 = require('argon2');
 const UserModel = require('../models/user');
 
 exports.showLogin = (req, res) => {
-  res.render('login', { title: 'Login', csrfToken: req.csrfToken() });
+  res.render('login', {
+    title: 'Login',
+    csrfToken: req.csrfToken(),
+    scripts: [
+      'https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js',
+      '/js/login.js'
+    ]
+  });
 };
 
 exports.login = async (req, res) => {

--- a/public/js/login.js
+++ b/public/js/login.js
@@ -1,0 +1,48 @@
+// public/js/login.js
+// Handles login submission via fetch and exposes an axios helper.
+
+(function() {
+  document.addEventListener('DOMContentLoaded', () => {
+    const form = document.querySelector('form[action="/login"]');
+    if (!form) return;
+
+    form.addEventListener('submit', async event => {
+      event.preventDefault();
+      const data = Object.fromEntries(new FormData(form));
+
+      try {
+        const response = await fetch('/login', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json'
+          },
+          credentials: 'include',
+          body: JSON.stringify(data)
+        });
+
+        if (response.redirected) {
+          window.location.href = response.url;
+          return;
+        }
+
+        if (response.ok) {
+          window.location.href = '/';
+          return;
+        }
+
+        const result = await response.json().catch(() => ({}));
+        alert(result.error || 'Falha no login');
+      } catch (err) {
+        console.error('Erro no login:', err);
+        alert('Erro ao realizar login');
+      }
+    });
+  });
+
+  // Axios helper with withCredentials
+  window.loginWithAxios = function(data) {
+    return axios.post('/login', data, { withCredentials: true });
+  };
+})();
+


### PR DESCRIPTION
## Summary
- load Axios and a new login script on the login view
- submit login via `fetch` with `credentials: 'include'`
- provide an Axios helper using `{ withCredentials: true }`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc4512cf888324a2e4e78b3e18334a