### PR TITLE
docs: document rate limiting policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,29 @@ late/
 - **Validações por Schema** (express-validator)
 - **Rate Limiting ativo**
 
+## ⏱️ Rate Limiting
+
+Para proteger o serviço contra abuso, duas políticas de limite de requisições estão ativas:
+
+- **Global `/api`**: máximo de **100 requisições** a cada **15 minutos** por IP.
+- **`/login`**: máximo de **20 requisições** a cada **15 minutos** por IP.
+
+### Verificando os limites
+
+Cada resposta dessas rotas inclui cabeçalhos que informam seu status dentro da janela:
+
+- `X-RateLimit-Limit` – total de requisições permitidas na janela.
+- `X-RateLimit-Remaining` – quantas requisições restam.
+- `Retry-After` – presente ao atingir o limite, indica em quantos segundos tentar novamente.
+
+Exemplo:
+
+```bash
+curl -i https://late.miahchat.com/api/ping
+```
+
+Confira os valores dos cabeçalhos acima para confirmar a aplicação dos limites.
+
 ## 🚀 Instalação e Execução
 
 ### Requisitos


### PR DESCRIPTION
## Summary
- explain API and login rate limiting windows
- note headers for checking remaining quota

## Testing
- `npm test` *(fails: Module did not self-register: '/workspace/LATE/node_modules/better-sqlite3/build/Release/better_sqlite3.node')*

------
https://chatgpt.com/codex/tasks/task_e_68bc4bbeaad48324b0792d1d62dea97a