### PR TITLE
Validate name and email during registration

### DIFF
--- a/routes/web.js
+++ b/routes/web.js
@@ -35,10 +35,11 @@ router.post(
   requireAuth,
   requireRole('ADMIN'),
   csrfProtection,
-  body('username').notEmpty(),
+  body('name').notEmpty(),
+  body('email').isEmail(),
   body('password').isLength({ min: 6 }),
   body('role').optional().isIn(['ADMIN', 'USER']),
-  userController.create
+  (req, res) => userController.create(req, res)
 );
 
 // Dashboard

--- a/views/register.ejs
+++ b/views/register.ejs
@@ -7,8 +7,12 @@
     <form method="POST" action="/register">
       <input type="hidden" name="_csrf" value="<%= csrfToken %>">
       <div class="mb-3">
-        <label for="username" class="form-label">Usuário</label>
-        <input type="text" class="form-control" id="username" name="username">
+        <label for="name" class="form-label">Nome</label>
+        <input type="text" class="form-control" id="name" name="name">
+      </div>
+      <div class="mb-3">
+        <label for="email" class="form-label">E-mail</label>
+        <input type="email" class="form-control" id="email" name="email">
       </div>
       <div class="mb-3">
         <label for="password" class="form-label">Senha</label>


### PR DESCRIPTION
## Summary
- validate name and email for admin user registration
- add name and email fields to registration form

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc4f553fc083249e9bdb356a6ae7ff