### PR TITLE
Use CORS_ORIGINS environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Environment variable examples for LATE
-# Allowed origins for CORS (comma-separated)
+# Allowed origins for CORS (comma-separated, e.g., http://localhost:3000,http://localhost:8080)
 CORS_ORIGINS=https://late.miahchat.com,https://www.late.miahchat.com
 
 # Session secret for signing cookies

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Confira os valores dos cabeçalhos acima para confirmar a aplicação dos limite
 git clone <repo>
 cd late
 npm install
-# Defina os domínios permitidos no CORS
+# Defina os domínios permitidos no CORS via CORS_ORIGINS
 export CORS_ORIGINS=http://localhost:3000,http://localhost:8080
 npm start
 Acesse: http://localhost:3000 ou http://<SEU-IP>:3000

--- a/config/cors.js
+++ b/config/cors.js
@@ -5,8 +5,8 @@ const defaultOrigins = [
   'https://late.miahchat.com'
 ];
 
-const allowedOrigins = process.env.ALLOWED_ORIGINS
-  ? process.env.ALLOWED_ORIGINS.split(',').map(o => o.trim()).filter(Boolean)
+const allowedOrigins = process.env.CORS_ORIGINS
+  ? process.env.CORS_ORIGINS.split(',').map(o => o.trim()).filter(Boolean)
   : defaultOrigins;
 
 module.exports = { allowedOrigins };


### PR DESCRIPTION
## Summary
- read allowed origins from `CORS_ORIGINS`
- document `CORS_ORIGINS` usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc510c14648324a98b9a5c80f911aa