### PR TITLE
feat: add CORS_ORIGINS fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 # Environment variable examples for LATE
 # Allowed origins for CORS (comma-separated, e.g., http://localhost:3000,http://localhost:8080)
+# ALLOWED_ORIGINS is still supported but will be deprecated in the future
 CORS_ORIGINS=https://late.miahchat.com,https://www.late.miahchat.com
+# ALLOWED_ORIGINS=https://late.miahchat.com,https://www.late.miahchat.com
 
 # Session secret for signing cookies
 SESSION_SECRET=CHANGE_THIS

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ git clone <repo>
 cd late
 npm install
 # Defina os domínios permitidos no CORS via CORS_ORIGINS
+# (ALLOWED_ORIGINS ainda é suportada, mas será descontinuada futuramente)
 export CORS_ORIGINS=http://localhost:3000,http://localhost:8080
 # Opcional: quantidade de proxies de confiança (quando atrás de proxy reverso)
 export TRUST_PROXY=1

--- a/config/cors.js
+++ b/config/cors.js
@@ -5,8 +5,10 @@ const defaultOrigins = [
   'https://late.miahchat.com'
 ];
 
-const allowedOrigins = process.env.CORS_ORIGINS
-  ? process.env.CORS_ORIGINS.split(',').map(o => o.trim()).filter(Boolean)
+const originsEnv = process.env.CORS_ORIGINS || process.env.ALLOWED_ORIGINS;
+
+const allowedOrigins = originsEnv
+  ? originsEnv.split(',').map(o => o.trim()).filter(Boolean)
   : defaultOrigins;
 
 module.exports = { allowedOrigins };


### PR DESCRIPTION
## Summary
- allow using CORS_ORIGINS or ALLOWED_ORIGINS for CORS configuration
- document that ALLOWED_ORIGINS is still supported but will be removed in the future

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc568897588324a3030eb649ef4462