### PR TITLE
fix: handle express v5 wildcard options

### DIFF
--- a/server.js
+++ b/server.js
@@ -47,7 +47,9 @@ app.set('views', path.join(__dirname, 'views'));
 
 // ─── Segurança, Limites e Middleware ─────────────────────────────────────────
 app.use(corsMw);
-app.options('*', corsMw);
+// Express 5 with path-to-regexp v7 cannot parse a bare '*' path.
+// Use a regex to handle CORS preflight requests on any route.
+app.options(/.*/, corsMw);
 app.use(helmet({
   contentSecurityPolicy: {
     directives: {


### PR DESCRIPTION
## Summary
- fix Express 5 startup crash by replacing `app.options('*')` with regex for preflight

## Testing
- `npm test` *(fails: table users already exists / no such table: recados)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7f45d3848324a1a036226761d250