### PR TITLE
Preserve existing data when editing recados

### DIFF
--- a/views/editar-recado.ejs
+++ b/views/editar-recado.ejs
@@ -15,34 +15,76 @@
             <p class="card-subtitle">Edite os campos necessários</p>
           </div>
           <div class="card-body">
-            <div class="form-group">
-              <label for="destinatario" class="form-label required">Destinatário</label>
-              <input id="destinatario" name="destinatario" type="text" class="form-input" required data-label="Destinatário" />
-            </div>
-            <div class="form-group">
-              <label for="remetente_nome" class="form-label required">Remetente</label>
-              <input id="remetente_nome" name="remetente_nome" type="text" class="form-input" required data-label="Remetente" />
-            </div>
-            <div class="form-group">
-              <label for="assunto" class="form-label required">Assunto</label>
-              <input id="assunto" name="assunto" type="text" class="form-input" required data-label="Assunto" />
-            </div>
-            <div class="form-group">
-              <label for="observacoes" class="form-label">Observações</label>
-              <textarea id="observacoes" name="observacoes" class="form-textarea" rows="4"></textarea>
-            </div>
-            <div class="form-group">
-              <label for="situacao" class="form-label">Situação</label>
-              <select id="situacao" name="situacao" class="form-select">
-                <option value="pendente">Pendente</option>
-                <option value="em_andamento">Em Andamento</option>
-                <option value="resolvido">Resolvido</option>
-              </select>
-            </div>
+            <fieldset style="border: 1px solid var(--border-light); border-radius: var(--radius); padding: 1.5rem; margin-bottom: 2rem;">
+              <legend style="padding: 0 0.5rem; font-weight: 600; color: var(--text-primary);">📞 Dados da Ligação</legend>
+              <div class="form-grid-2">
+                <div class="form-group">
+                  <label for="data_ligacao" class="form-label required">Data da Ligação</label>
+                  <input id="data_ligacao" name="data_ligacao" type="date" class="form-input" required data-label="Data da ligação" autocomplete="bday" />
+                </div>
+                <div class="form-group">
+                  <label for="hora_ligacao" class="form-label required">Hora da Ligação</label>
+                  <input id="hora_ligacao" name="hora_ligacao" type="time" class="form-input" required data-label="Hora da ligação" autocomplete="off" />
+                </div>
+              </div>
+              <div class="form-group">
+                <label for="destinatario" class="form-label required">Destinatário</label>
+                <input id="destinatario" name="destinatario" type="text" class="form-input" placeholder="Nome da pessoa ou setor que deve receber o recado" required data-label="Destinatário" autocomplete="organization" />
+                <div class="form-help">Pessoa ou setor responsável por receber esta mensagem</div>
+              </div>
+            </fieldset>
+
+            <fieldset style="border: 1px solid var(--border-light); border-radius: var(--radius); padding: 1.5rem; margin-bottom: 2rem;">
+              <legend style="padding: 0 0.5rem; font-weight: 600; color: var(--text-primary);">👤 Dados do Remetente</legend>
+              <div class="form-group">
+                <label for="remetente_nome" class="form-label required">Nome do Remetente</label>
+                <input id="remetente_nome" name="remetente_nome" type="text" class="form-input" placeholder="Nome completo de quem ligou" required data-label="Nome do remetente" autocomplete="name" />
+              </div>
+              <div class="form-grid-2">
+                <div class="form-group">
+                  <label for="remetente_telefone" class="form-label">Telefone</label>
+                  <input id="remetente_telefone" name="remetente_telefone" type="tel" class="form-input" placeholder="(11) 99999-9999" autocomplete="tel" />
+                  <div class="form-help">Telefone para retorno (opcional)</div>
+                </div>
+                <div class="form-group">
+                  <label for="remetente_email" class="form-label">E-mail</label>
+                  <input id="remetente_email" name="remetente_email" type="email" class="form-input" placeholder="email@exemplo.com" autocomplete="email" />
+                  <div class="form-help">E-mail para contato (opcional)</div>
+                </div>
+              </div>
+              <div class="form-group">
+                <label for="horario_retorno" class="form-label">Horário para Retorno</label>
+                <input id="horario_retorno" name="horario_retorno" type="text" class="form-input" placeholder="Ex: Das 9h às 17h, Após 14h, etc." autocomplete="off" />
+                <div class="form-help">Melhor horário para retornar a ligação (opcional)</div>
+              </div>
+            </fieldset>
+
+            <fieldset style="border: 1px solid var(--border-light); border-radius: var(--radius); padding: 1.5rem; margin-bottom: 2rem;">
+              <legend style="padding: 0 0.5rem; font-weight: 600; color: var(--text-primary);">📝 Conteúdo do Recado</legend>
+              <div class="form-group">
+                <label for="assunto" class="form-label required">Assunto</label>
+                <input id="assunto" name="assunto" type="text" class="form-input" placeholder="Resumo do motivo da ligação" required data-label="Assunto" autocomplete="off" />
+                <div class="form-help">Descreva brevemente o motivo da ligação</div>
+              </div>
+              <div class="form-group">
+                <label for="observacoes" class="form-label">Observações</label>
+                <textarea id="observacoes" name="observacoes" class="form-textarea" rows="4" placeholder="Detalhes adicionais, contexto ou informações importantes sobre o recado..." autocomplete="off"></textarea>
+                <div class="form-help">Informações adicionais que possam ser úteis (opcional)</div>
+              </div>
+              <div class="form-group">
+                <label for="situacao" class="form-label">Situação</label>
+                <select id="situacao" name="situacao" class="form-select" autocomplete="off">
+                  <option value="pendente">Pendente</option>
+                  <option value="em_andamento">Em Andamento</option>
+                  <option value="resolvido">Resolvido</option>
+                </select>
+                <div class="form-help">Status atual do recado</div>
+              </div>
+            </fieldset>
           </div>
           <div class="card-footer">
             <div style="display:flex;gap:1rem;justify-content:flex-end;">
-              <a href="/recados" class="btn btn-outline">Cancelar</a>
+              <a id="btnCancelar" href="/recados" class="btn btn-outline">Cancelar</a>
               <button type="submit" class="btn btn-primary" id="btnSalvar">💾 Salvar</button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Extend edit recado view with full ligação and remetente fields
- Merge fetched data with form input to avoid overwriting untouched values
- Submit only meaningful fields to prevent blank updates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bfa83a33488324996d2e4554e9b29d