### PR TITLE
Fix CORS origin parsing and allow CSRF header

### DIFF
--- a/config/cors.js
+++ b/config/cors.js
@@ -5,10 +5,14 @@ const defaultOrigins = [
   'https://late.miahchat.com'
 ];
 
-const originsEnv = process.env.CORS_ORIGINS || process.env.ALLOWED_ORIGINS;
+// Aceita lista separada por vírgula ou espaço nas variáveis de ambiente
+const originsEnv = process.env.CORS_ORIGINS || process.env.ALLOWED_ORIGINS || '';
+const envOrigins = originsEnv
+  .split(/[\s,]+/)
+  .map(o => o.trim())
+  .filter(Boolean);
 
-const allowedOrigins = originsEnv
-  ? originsEnv.split(',').map(o => o.trim()).filter(Boolean)
-  : defaultOrigins;
+// Garante que os domínios padrão estejam sempre permitidos
+const allowedOrigins = Array.from(new Set([...defaultOrigins, ...envOrigins]));
 
 module.exports = { allowedOrigins };

--- a/middleware/cors.js
+++ b/middleware/cors.js
@@ -16,7 +16,7 @@ const corsOptions = {
     },
     credentials: true,
     methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
-    allowedHeaders: ['Content-Type', 'Authorization', 'X-Requested-With']
+    allowedHeaders: ['Content-Type', 'Authorization', 'X-Requested-With', 'X-CSRF-Token']
 };
 
 module.exports = cors(corsOptions);


### PR DESCRIPTION
## Summary
- ensure default origins are preserved and allow env-defined origins separated by commas or spaces
- allow X-CSRF-Token header in CORS configuration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0bb139a9c8324b826f2304ab39d84