### PR TITLE
Provide default errors array in registration view

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -56,7 +56,8 @@ exports.login = async (req, res) => {
 exports.showRegister = (req, res) => {
   res.render('register', {
     title: 'Registrar',
-    csrfToken: req.csrfToken()
+    csrfToken: req.csrfToken(),
+    errors: []
   });
 };
 

--- a/views/register.ejs
+++ b/views/register.ejs
@@ -18,7 +18,7 @@
         <label for="password" class="form-label">Senha</label>
         <input type="password" class="form-control" id="password" name="password">
       </div>
-      <% if (Array.isArray(errors)) { %>
+      <% if (typeof errors !== 'undefined' && Array.isArray(errors)) { %>
         <div class="alert alert-danger">
           <ul class="mb-0">
             <% errors.forEach(e => { %>


### PR DESCRIPTION
## Summary
- Render register view with an empty errors array to avoid undefined checks
- Harden errors guard in register template to ensure it's defined before rendering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0e03eb8c48324acefc943e6c9bd90