### PR TITLE
Remove redundant user register handler

### DIFF
--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -42,7 +42,3 @@ exports.setActive = (req, res) => {
   }
   res.json({ success: true });
 };
-
-exports.showRegister = (req, res) => {
-  res.render('register', { title: 'Registrar Usuário', csrfToken: req.csrfToken() });
-};


### PR DESCRIPTION
## Summary
- drop unused `showRegister` from user controller so auth controller exclusively handles registration

## Testing
- `npm test`
- `curl -s localhost:3000/register`


------
https://chatgpt.com/codex/tasks/task_e_68c17e2be184832485501e42aff7aefe