### PR TITLE
Protect registration routes with admin-only access

### DIFF
--- a/routes/web.js
+++ b/routes/web.js
@@ -21,10 +21,18 @@ router.post(
 router.get('/logout', requireAuth, authController.logout);
 
 // Registro de usuários
-router.get('/register', csrfProtection, authController.showRegister);
+router.get(
+  '/register',
+  requireAuth,
+  requireRole('ADMIN'),
+  csrfProtection,
+  authController.showRegister
+);
 
 router.post(
   '/register',
+  requireAuth,
+  requireRole('ADMIN'),
   csrfProtection,
   body('name').notEmpty(),
   body('email').isEmail(),


### PR DESCRIPTION
## Summary
- require authentication and ADMIN role for GET and POST /register routes
- add tests verifying redirect for unauthenticated users and 403 for non-admins

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c19b4c52388324a2eec0f549121c6b