### PR TITLE
Configure session cookie security per environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Sistema web para registro de ligações e recados",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js",
+    "start": "NODE_ENV=production node server.js",
     "dev": "nodemon server.js",
     "test": "jest --runInBand --coverage",
     "lighthouse": "lighthouse http://localhost:3000 --output html --output json --output-path ./lighthouse-reports/report",

--- a/server.js
+++ b/server.js
@@ -110,7 +110,8 @@ app.use(
     resave: false,
     saveUninitialized: false,
     cookie: {
-      secure: true,
+      // Only use secure cookies in production to allow HTTP during development
+      secure: process.env.NODE_ENV === 'production',
       httpOnly: true,
       sameSite: process.env.SAMESITE || 'lax'
     }


### PR DESCRIPTION
## Summary
- Allow insecure cookies in development by tying session cookie `secure` flag to `NODE_ENV`
- Set `npm start` to run with `NODE_ENV=production`

## Testing
- `npm test` *(fails: SQLITE_ERROR)*

------
https://chatgpt.com/codex/tasks/task_e_68c1fc04a8408324b7b7d26b064ad59e