### PR TITLE
Handle login errors consistently

### DIFF
--- a/__tests__/rate-limit.diagnostic.test.js
+++ b/__tests__/rate-limit.diagnostic.test.js
@@ -7,8 +7,11 @@ describe('Rate limit – diagnóstico', () => {
     const agent = request.agent(app);
 
     // 1) Primeira chamada revela o teto (via headers)
-    const first = await agent.get('/login').set('Accept', 'text/html');
-    expect([200,302]).toContain(first.status);
+    const first = await agent
+      .post('/login')
+      .set('Accept', 'application/json')
+      .set('X-Forwarded-For', '1.2.3.4');
+    expect([200, 302, 400, 401, 403]).toContain(first.status);
 
     const limit = Number(first.headers['x-ratelimit-limit'] || 20);
     expect(Number.isFinite(limit) && limit > 0).toBe(true);
@@ -16,15 +19,18 @@ describe('Rate limit – diagnóstico', () => {
     // 2) Consumir o saldo até estourar
     let last = first;
     for (let i = 0; i < limit + 2; i++) {
-      last = await agent.get('/login').set('Accept', 'text/html');
-      // Permitimos 200/302 enquanto houver saldo; ao estourar deve virar 429
+      last = await agent
+        .post('/login')
+        .set('Accept', 'application/json')
+        .set('X-Forwarded-For', '1.2.3.4');
+      // Permitimos respostas enquanto houver saldo; ao estourar deve virar 429
       if (last.status === 429) break;
     }
 
     // 3) Verifica que houve bloqueio por rate limit
     expect(last.status).toBe(429);
     const body = typeof last.body === 'object' ? last.body : {};
-    const msg = body.message || (last.text || '').slice(0, 120);
+    const msg = body.error || body.message || (last.text || '').slice(0, 120);
     expect(String(msg)).toMatch(/Muitas requisições/i);
   });
 });

--- a/public/js/login.js
+++ b/public/js/login.js
@@ -37,7 +37,7 @@
         }
 
         const result = await response.json().catch(() => ({}));
-        alert(result.error || 'Falha no login');
+        alert(result.error || result.message || 'Falha no login');
       } catch (err) {
         console.error('Erro no login:', err);
         alert('Erro ao realizar login');

--- a/server.js
+++ b/server.js
@@ -80,7 +80,7 @@ const loginLimiter = rateLimit({
   max: 20,
   message: {
     success: false,
-    message: 'Muitas requisições. Tente novamente em 15 minutos.'
+    error: 'Muitas requisições. Tente novamente em 15 minutos.'
   },
   skip: req => req.method !== 'POST'
 });


### PR DESCRIPTION
## Summary
- Surface server `error` or `message` fields on login failure
- Return `error` field from login rate limiter instead of `message`
- Align rate limit diagnostic test with new error field and POST semantics

## Testing
- `npm test` *(fails: __tests__/api.recados.test.js, __tests__/recado.model.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c1fc17c2948324a72696c672c0366c