### PR TITLE
Return JSON responses for login errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,12 @@ Headers esperados:
 - `Access-Control-Allow-Credentials: true`
 - `Set-Cookie: session=<id>; Path=/; HttpOnly; SameSite=None; Secure`
 
+Se o cabeçalho `Accept` incluir `application/json`, respostas de erro do `/login` serão retornadas em JSON no formato:
+
+```json
+{ "error": "Credenciais inválidas" }
+```
+
 ### Ping autenticado
 
 ```bash

--- a/__tests__/auth.login.json.test.js
+++ b/__tests__/auth.login.json.test.js
@@ -1,0 +1,27 @@
+const request = require('supertest');
+const app = require('../server');
+
+function getCsrf(html) {
+  const m = html && html.match(/name="(_csrf|csrfToken)".*?value="([^"]+)"/i);
+  return m ? m[2] : null;
+}
+
+describe('Login JSON responses', () => {
+  test('retorna JSON quando Accept inclui application/json', async () => {
+    const agent = request.agent(app);
+
+    const res = await agent.get('/login').set('Accept', 'text/html');
+    expect(res.status).toBe(200);
+    const token = getCsrf(res.text);
+    expect(token).toBeTruthy();
+
+    const post = await agent
+      .post('/login')
+      .set('Accept', 'application/json')
+      .send({ email: 'naoexiste@example.com', password: 'senha', _csrf: token });
+
+    expect(post.status).toBe(401);
+    expect(post.type).toMatch(/json/);
+    expect(post.body).toEqual({ error: 'Credenciais inválidas' });
+  });
+});

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -17,6 +17,9 @@ exports.showLogin = (req, res) => {
 exports.login = async (req, res) => {
   const errors = validationResult(req);
   if (!errors.isEmpty()) {
+    if (req.accepts('json')) {
+      return res.status(400).json({ error: 'Dados inválidos' });
+    }
     return res.status(400).render('login', {
       title: 'Login',
       csrfToken: req.csrfToken(),
@@ -27,6 +30,9 @@ exports.login = async (req, res) => {
   const { email, password } = req.body;
   const user = UserModel.findByEmail(email);
   if (!user || !user.is_active) {
+    if (req.accepts('json')) {
+      return res.status(401).json({ error: 'Credenciais inválidas' });
+    }
     return res.status(401).render('login', {
       title: 'Login',
       csrfToken: req.csrfToken(),
@@ -37,6 +43,9 @@ exports.login = async (req, res) => {
   try {
     const valid = await argon2.verify(user.password_hash, password, { type: argon2.argon2id });
     if (!valid) {
+      if (req.accepts('json')) {
+        return res.status(401).json({ error: 'Credenciais inválidas' });
+      }
       return res.status(401).render('login', {
         title: 'Login',
         csrfToken: req.csrfToken(),
@@ -47,6 +56,9 @@ exports.login = async (req, res) => {
     res.redirect('/');
   } catch (err) {
     console.error('Erro ao verificar senha:', err);
+    if (req.accepts('json')) {
+      return res.status(500).json({ error: 'Erro interno' });
+    }
     res.status(500).render('login', {
       title: 'Login',
       csrfToken: req.csrfToken(),


### PR DESCRIPTION
## Summary
- serve JSON error responses from login when client requests JSON
- document login JSON error format
- test login endpoint returns JSON errors with Accept header

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1feb4c4a88324b2b24ca40cb45ad0