### PR TITLE
Ensure non-admin registrations default to OPERADOR

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -68,34 +68,32 @@ exports.login = async (req, res) => {
 };
 
 exports.showRegister = (req, res) => {
+  const roles = req.session.user?.role === 'ADMIN' ? ALLOWED_ROLES : ['OPERADOR'];
   res.render('register', {
     title: 'Registrar',
     csrfToken: req.csrfToken(),
     errors: [],
-    roles: ALLOWED_ROLES
+    roles,
+    selectedRole: undefined
   });
 };
 
 exports.register = async (req, res) => {
   const errors = validationResult(req);
+  const { name, email, password, role: requestedRole } = req.body;
+  const role =
+    req.session.user?.role === 'ADMIN' && ALLOWED_ROLES.includes(requestedRole)
+      ? requestedRole
+      : 'OPERADOR';
+  const roles = req.session.user?.role === 'ADMIN' ? ALLOWED_ROLES : ['OPERADOR'];
+
   if (!errors.isEmpty()) {
     return res.status(400).render('register', {
       title: 'Registrar',
       csrfToken: req.csrfToken(),
       errors: errors.array(),
-      roles: ALLOWED_ROLES
-    });
-  }
-
-  const { name, email, password, role } = req.body;
-
-  if (!ALLOWED_ROLES.includes(role)) {
-    return res.status(400).render('register', {
-      title: 'Registrar',
-      csrfToken: req.csrfToken(),
-      errors: [],
-      error: 'Perfil inválido',
-      roles: ALLOWED_ROLES
+      roles,
+      selectedRole: requestedRole
     });
   }
 
@@ -112,7 +110,8 @@ exports.register = async (req, res) => {
         title: 'Registrar',
         csrfToken: req.csrfToken(),
         error: 'E-mail já cadastrado',
-        roles: ALLOWED_ROLES
+        roles,
+        selectedRole: requestedRole
       });
     }
     console.error('Erro ao registrar usuário:', err);
@@ -120,7 +119,8 @@ exports.register = async (req, res) => {
       title: 'Registrar',
       csrfToken: req.csrfToken(),
       error: 'Erro interno',
-      roles: ALLOWED_ROLES
+      roles,
+      selectedRole: requestedRole
     });
   }
 };


### PR DESCRIPTION
## Summary
- Guard registration role selection so only admins may choose non-OPERADOR roles
- Pass selected role to registration views and adjust available roles per session
- Test that unauthenticated signups always create OPERADOR users

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1ff6a7b248324841320d8f3f2dca1