### PR TITLE
Ensure default role selection and form value persistence

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -72,7 +72,10 @@ exports.showRegister = (req, res) => {
     title: 'Registrar',
     csrfToken: req.csrfToken(),
     errors: [],
-    roles: ALLOWED_ROLES
+    roles: ALLOWED_ROLES,
+    selectedRole: undefined,
+    name: '',
+    email: ''
   });
 };
 
@@ -83,7 +86,10 @@ exports.register = async (req, res) => {
       title: 'Registrar',
       csrfToken: req.csrfToken(),
       errors: errors.array(),
-      roles: ALLOWED_ROLES
+      roles: ALLOWED_ROLES,
+      selectedRole: req.body.role,
+      name: req.body.name,
+      email: req.body.email
     });
   }
 
@@ -95,7 +101,10 @@ exports.register = async (req, res) => {
       csrfToken: req.csrfToken(),
       errors: [],
       error: 'Perfil inválido',
-      roles: ALLOWED_ROLES
+      roles: ALLOWED_ROLES,
+      selectedRole: req.body.role,
+      name: req.body.name,
+      email: req.body.email
     });
   }
 
@@ -112,7 +121,10 @@ exports.register = async (req, res) => {
         title: 'Registrar',
         csrfToken: req.csrfToken(),
         error: 'E-mail já cadastrado',
-        roles: ALLOWED_ROLES
+        roles: ALLOWED_ROLES,
+        selectedRole: req.body.role,
+        name: req.body.name,
+        email: req.body.email
       });
     }
     console.error('Erro ao registrar usuário:', err);
@@ -120,7 +132,10 @@ exports.register = async (req, res) => {
       title: 'Registrar',
       csrfToken: req.csrfToken(),
       error: 'Erro interno',
-      roles: ALLOWED_ROLES
+      roles: ALLOWED_ROLES,
+      selectedRole: req.body.role,
+      name: req.body.name,
+      email: req.body.email
     });
   }
 };

--- a/views/register.ejs
+++ b/views/register.ejs
@@ -8,11 +8,11 @@
       <input type="hidden" name="_csrf" value="<%= csrfToken %>">
       <div class="mb-3">
         <label for="name" class="form-label">Nome</label>
-        <input type="text" class="form-control" id="name" name="name">
+        <input type="text" class="form-control" id="name" name="name" value="<%= typeof name !== 'undefined' ? name : '' %>">
       </div>
       <div class="mb-3">
         <label for="email" class="form-label">E-mail</label>
-        <input type="email" class="form-control" id="email" name="email">
+        <input type="email" class="form-control" id="email" name="email" value="<%= typeof email !== 'undefined' ? email : '' %>">
       </div>
       <div class="mb-3">
         <label for="password" class="form-label">Senha</label>
@@ -23,7 +23,7 @@
         <select id="role" name="role" class="form-select">
           <% if (Array.isArray(roles)) { %>
             <% roles.forEach(r => { %>
-              <option value="<%= r %>"><%= r %></option>
+              <option value="<%= r %>" <%= (selectedRole ? selectedRole === r : r === 'OPERADOR') ? 'selected' : '' %>><%= r %></option>
             <% }) %>
           <% } %>
         </select>


### PR DESCRIPTION
## Summary
- Default to OPERADOR in register role dropdown and keep user's choice
- Pass selected role, name, and email back to register view for re-render
- Refill register form fields after validation errors for better UX

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c200985288832499ad8642f391b3d2