### PR TITLE
Allow argon2 to auto-detect hash variant

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -42,7 +42,7 @@ exports.login = async (req, res) => {
   }
 
   try {
-    const valid = await argon2.verify(user.password_hash, password, { type: argon2.argon2id });
+    const valid = await argon2.verify(user.password_hash, password);
     if (!valid) {
       if (req.accepts('json')) {
         return res.status(401).json({ error: 'Credenciais inválidas' });


### PR DESCRIPTION
## Summary
- let argon2 decide the hash variant when verifying passwords
- keep argon2id as the default when hashing new passwords

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7727a8ce0832485ad5fe15e43d3c1