### PR TITLE
Clarify login failure messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,13 @@ Headers esperados:
 Se o cabeçalho `Accept` incluir `application/json`, respostas de erro do `/login` serão retornadas em JSON no formato:
 
 ```json
-{ "error": "Credenciais inválidas" }
+{ "error": "Usuário não encontrado ou inativo" }
+```
+
+ou
+
+```json
+{ "error": "Senha incorreta" }
 ```
 
 ### Ping autenticado

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -31,26 +31,28 @@ exports.login = async (req, res) => {
   const email = req.body.email.trim().toLowerCase();
   const user = UserModel.findByEmail(email);
   if (!user || !user.is_active) {
+    const errorMsg = 'Usuário não encontrado ou inativo';
     if (req.accepts('json')) {
-      return res.status(401).json({ error: 'Credenciais inválidas' });
+      return res.status(401).json({ error: errorMsg });
     }
     return res.status(401).render('login', {
       title: 'Login',
       csrfToken: req.csrfToken(),
-      error: 'Credenciais inválidas',
+      error: errorMsg,
     });
   }
 
   try {
     const valid = await argon2.verify(user.password_hash, password);
     if (!valid) {
+      const errorMsg = 'Senha incorreta';
       if (req.accepts('json')) {
-        return res.status(401).json({ error: 'Credenciais inválidas' });
+        return res.status(401).json({ error: errorMsg });
       }
       return res.status(401).render('login', {
         title: 'Login',
         csrfToken: req.csrfToken(),
-        error: 'Credenciais inválidas',
+        error: errorMsg,
       });
     }
     req.session.user = { id: user.id, name: user.name, email: user.email, role: user.role };


### PR DESCRIPTION
## Summary
- Return `Usuário não encontrado ou inativo` when user is missing or inactive
- Return `Senha incorreta` when password verification fails
- Document new login error messages in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c774c9915c8324b1036afd0181681a