### PR TITLE
Fix login warning message syntax

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -32,7 +32,7 @@ exports.login = async (req, res) => {
   const user = UserModel.findByEmail(email);
 
   if (!user || Number(user.is_active) !== 1) {
-    console.warn('Login failed', { email, reason: 'Usuário não encontrado ou inativo });
+    console.warn('Login failed', { email, reason: 'Usuário não encontrado ou inativo' });
     if (req.accepts('json')) {
       return res.status(401).json({ error: errorMsg });
     }


### PR DESCRIPTION
## Summary
- fix the console.warn message when a user is not found or inactive

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68c871e7a0888324a3349a3fc0254877