### PR TITLE
feat(view): atualiza formulários e scripts para novos campos de messages

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -74,13 +74,19 @@ const Modal = { /* … */ };
 /**
  * Retorna o rótulo legível para cada situação
  */
-function getSituacaoLabel(situacao) {
-  const labels = { pendente: 'Pendente', em_andamento: 'Em Andamento', resolvido: 'Resolvido' };
-  return labels[situacao] || situacao;
+function getStatusLabel(status) {
+  const labels = { pending: 'Pendente', in_progress: 'Em Andamento', resolved: 'Resolvido' };
+  if (typeof Normalizer !== 'undefined' && Normalizer && typeof Normalizer.normalizeStatus === 'function') {
+    const normalized = Normalizer.normalizeStatus(status);
+    if (labels[normalized]) return labels[normalized];
+  }
+  const key = String(status || '').toLowerCase().replace(/\s+/g, '_');
+  return labels[key] || labels[status] || (status == null ? '-' : status);
 }
 
 // Expõe globalmente
-window.getSituacaoLabel = getSituacaoLabel;
+window.getStatusLabel = getStatusLabel;
+window.getSituacaoLabel = getStatusLabel;
 
 // ─── INICIALIZAÇÃO LAZY ──────────────────────────────────────────────────────
 

--- a/public/js/novo-recado.js
+++ b/public/js/novo-recado.js
@@ -1,6 +1,6 @@
 // public/js/novo-recado.js
 // Página "Novo Recado" — coleta do formulário, normalização e envio para a API.
-// Por quê: garantir JSON válido e presença de 'mensagem' (fallback de 'observacoes').
+// Por quê: garantir JSON válido e presença de 'message' (fallback de 'notes').
 
 (() => {
   console.log('✅ Novo Recado JS carregado');
@@ -13,34 +13,38 @@
   };
 
   function coletarDados() {
-    const data_ligacao = val('#data_ligacao');
-    const hora_ligacao = val('#hora_ligacao');
-    const destinatario = val('#destinatario');
-    const remetente_nome = val('#remetente_nome');
-    const remetente_telefone = val('#remetente_telefone');
-    const remetente_email = val('#remetente_email');
-    const assunto = val('#assunto');
-    const situacao = val('#situacao') || 'pendente';
-    const horario_retorno = val('#horario_retorno');
-    const observacoes = val('#observacoes');
+    const call_date = val('#call_date');
+    const call_time = val('#call_time');
+    const recipient = val('#recipient');
+    const sender_name = val('#sender_name');
+    const sender_phone = val('#sender_phone');
+    const sender_email = val('#sender_email');
+    const subject = val('#subject');
+    const status = val('#status') || 'pending';
+    const callback_time = val('#callback_time');
+    const notes = val('#notes');
 
-    // 'mensagem' pode não existir no template atual; tentamos capturar, senão criamos fallback
-    const mensagemRaw = val('#mensagem'); // se não existir, retorna ''
-    const mensagem = (mensagemRaw || observacoes || '(sem mensagem)');
+    // 'message' pode não existir no template atual; tentamos capturar, senão criamos fallback
+    const messageRaw = val('#message'); // se não existir, retorna ''
+    const message = (messageRaw || notes || '(sem mensagem)');
 
-    const payload = {
-      data_ligacao,
-      hora_ligacao,
-      destinatario,
-      remetente_nome,
-      remetente_telefone,
-      remetente_email,
-      assunto,
-      mensagem,            // <- obrigatório no banco; garantimos aqui
-      situacao,
-      horario_retorno,
-      observacoes
+    const basePayload = {
+      call_date,
+      call_time,
+      recipient,
+      sender_name,
+      sender_phone,
+      sender_email,
+      subject,
+      message,            // <- obrigatório no banco; garantimos aqui
+      status,
+      callback_time,
+      notes
     };
+
+    const payload = (typeof Form !== 'undefined' && Form && typeof Form.prepareMessagePayload === 'function')
+      ? Form.prepareMessagePayload(basePayload)
+      : basePayload;
 
     console.log('✅ Dados coletados:', payload);
     return payload;
@@ -53,23 +57,23 @@
 
       // Validação mínima no front para UX (backend também valida)
       const faltando = [];
-      if (!recado.data_ligacao) faltando.push('Data da ligação');
-      if (!recado.hora_ligacao) faltando.push('Hora da ligação');
-      if (!recado.destinatario) faltando.push('Destinatário');
-      if (!recado.remetente_nome) faltando.push('Remetente');
-      if (!recado.assunto) faltando.push('Assunto');
-      if (!recado.mensagem) faltando.push('Mensagem');
+      if (!recado.call_date) faltando.push('Data da ligação');
+      if (!recado.call_time) faltando.push('Hora da ligação');
+      if (!recado.recipient) faltando.push('Destinatário');
+      if (!recado.sender_name) faltando.push('Remetente');
+      if (!recado.subject) faltando.push('Assunto');
+      if (!recado.message) faltando.push('Mensagem');
 
       if (faltando.length) {
         alert(`Preencha os campos obrigatórios: ${faltando.join(', ')}`);
         return;
       }
 
-      const resp = await API.createRecado(recado);
+      const resp = await API.createMessage(recado);
       console.log('✅ Recado criado:', resp);
 
       // Redireciona para lista/detalhe após criar (ajuste conforme sua navegação)
-      if (resp?.sucesso) {
+      if (resp?.success) {
         window.location.href = '/recados';
       } else {
         alert('Não foi possível criar o recado.');
@@ -81,7 +85,7 @@
   }
 
   function iniciar() {
-    const form = document.querySelector('#form-novo-recado') || document.querySelector('form');
+    const form = document.querySelector('#formNovoRecado') || document.querySelector('#form-novo-recado') || document.querySelector('form');
     if (!form) {
       console.warn('⚠️ Formulário de novo recado não encontrado.');
       return;

--- a/public/js/recados.js
+++ b/public/js/recados.js
@@ -8,12 +8,12 @@
 
   async function carregarRecados() {
     try {
-      const resp = await API.listarRecados();
-      if (!resp || resp.sucesso === false) {
-        throw new Error(resp?.erro || 'Falha ao listar recados.');
+      const resp = await API.listMessages();
+      if (!resp || resp.success === false) {
+        throw new Error(resp?.error || resp?.message || 'Falha ao listar recados.');
       }
 
-      const lista = Array.isArray(resp?.dados) ? resp.dados : resp; // compat: alguns backends retornam objeto
+      const lista = Array.isArray(resp?.data) ? resp.data : resp; // compat: alguns backends retornam objeto
       renderizarLista(lista);
     } catch (err) {
       console.error('❌ Erro ao carregar recados:', err?.message || err);
@@ -35,9 +35,13 @@
     }
 
     const rows = itens.map((r) => {
-      const assunto = escapeHtml(r.assunto || '(sem assunto)');
-      const mensagem = escapeHtml((r.mensagem || r.observacoes || '(sem mensagem)')).slice(0, 120);
-      const criado = escapeHtml(r.criado_em || '');
+      const assunto = escapeHtml(r.subject || '(sem assunto)');
+      const mensagem = escapeHtml((r.message || r.notes || '(sem mensagem)')).slice(0, 120);
+      const criadoRaw = r.created_at || (r.call_date ? `${r.call_date} ${r.call_time || ''}` : '');
+      const criadoFmt = criadoRaw && typeof Utils !== 'undefined' && Utils && typeof Utils.formatDateTime === 'function'
+        ? Utils.formatDateTime(criadoRaw)
+        : criadoRaw;
+      const criado = escapeHtml(criadoFmt || '');
       return `
         <tr>
           <td>${assunto}</td>

--- a/public/js/relatorios.js
+++ b/public/js/relatorios.js
@@ -8,11 +8,11 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   // Estatísticas gerais numéricas
   try {
-    const stats = (await API.getStats()).data;
+    const stats = (await API.getMessageStats()).data;
     totalEl.textContent = stats.total;
-    pendEl.textContent  = stats.pendente;
-    andEl.textContent   = stats.em_andamento;
-    resEl.textContent   = stats.resolvido;
+    pendEl.textContent  = stats.pending;
+    andEl.textContent   = stats.in_progress;
+    resEl.textContent   = stats.resolved;
   } catch (e) {
     console.error('Erro ao carregar estatísticas:', e);
     totalEl.textContent = pendEl.textContent =

--- a/views/editar-recado.ejs
+++ b/views/editar-recado.ejs
@@ -19,17 +19,17 @@
               <legend style="padding: 0 0.5rem; font-weight: 600; color: var(--text-primary);">📞 Dados da Ligação</legend>
               <div class="form-grid-2">
                 <div class="form-group">
-                  <label for="data_ligacao" class="form-label required">Data da Ligação</label>
-                  <input id="data_ligacao" name="data_ligacao" type="date" class="form-input" required data-label="Data da ligação" autocomplete="bday" />
+                  <label for="call_date" class="form-label required">Data da Ligação</label>
+                  <input id="call_date" name="call_date" type="date" class="form-input" required data-label="Data da ligação" autocomplete="bday" />
                 </div>
                 <div class="form-group">
-                  <label for="hora_ligacao" class="form-label required">Hora da Ligação</label>
-                  <input id="hora_ligacao" name="hora_ligacao" type="time" class="form-input" required data-label="Hora da ligação" autocomplete="off" />
+                  <label for="call_time" class="form-label required">Hora da Ligação</label>
+                  <input id="call_time" name="call_time" type="time" class="form-input" required data-label="Hora da ligação" autocomplete="off" />
                 </div>
               </div>
               <div class="form-group">
-                <label for="destinatario" class="form-label required">Destinatário</label>
-                <input id="destinatario" name="destinatario" type="text" class="form-input" placeholder="Nome da pessoa ou setor que deve receber o recado" required data-label="Destinatário" autocomplete="organization" />
+                <label for="recipient" class="form-label required">Destinatário</label>
+                <input id="recipient" name="recipient" type="text" class="form-input" placeholder="Nome da pessoa ou setor que deve receber o recado" required data-label="Destinatário" autocomplete="organization" />
                 <div class="form-help">Pessoa ou setor responsável por receber esta mensagem</div>
               </div>
             </fieldset>
@@ -37,24 +37,24 @@
             <fieldset style="border: 1px solid var(--border-light); border-radius: var(--radius); padding: 1.5rem; margin-bottom: 2rem;">
               <legend style="padding: 0 0.5rem; font-weight: 600; color: var(--text-primary);">👤 Dados do Remetente</legend>
               <div class="form-group">
-                <label for="remetente_nome" class="form-label required">Nome do Remetente</label>
-                <input id="remetente_nome" name="remetente_nome" type="text" class="form-input" placeholder="Nome completo de quem ligou" required data-label="Nome do remetente" autocomplete="name" />
+                <label for="sender_name" class="form-label required">Nome do Remetente</label>
+                <input id="sender_name" name="sender_name" type="text" class="form-input" placeholder="Nome completo de quem ligou" required data-label="Nome do remetente" autocomplete="name" />
               </div>
               <div class="form-grid-2">
                 <div class="form-group">
-                  <label for="remetente_telefone" class="form-label">Telefone</label>
-                  <input id="remetente_telefone" name="remetente_telefone" type="tel" class="form-input" placeholder="(11) 99999-9999" autocomplete="tel" />
+                  <label for="sender_phone" class="form-label">Telefone</label>
+                  <input id="sender_phone" name="sender_phone" type="tel" class="form-input" placeholder="(11) 99999-9999" autocomplete="tel" />
                   <div class="form-help">Telefone para retorno (opcional)</div>
                 </div>
                 <div class="form-group">
-                  <label for="remetente_email" class="form-label">E-mail</label>
-                  <input id="remetente_email" name="remetente_email" type="email" class="form-input" placeholder="email@exemplo.com" autocomplete="email" />
+                  <label for="sender_email" class="form-label">E-mail</label>
+                  <input id="sender_email" name="sender_email" type="email" class="form-input" placeholder="email@exemplo.com" autocomplete="email" />
                   <div class="form-help">E-mail para contato (opcional)</div>
                 </div>
               </div>
               <div class="form-group">
-                <label for="horario_retorno" class="form-label">Horário para Retorno</label>
-                <input id="horario_retorno" name="horario_retorno" type="text" class="form-input" placeholder="Ex: Das 9h às 17h, Após 14h, etc." autocomplete="off" />
+                <label for="callback_time" class="form-label">Horário para Retorno</label>
+                <input id="callback_time" name="callback_time" type="text" class="form-input" placeholder="Ex: Das 9h às 17h, Após 14h, etc." autocomplete="off" />
                 <div class="form-help">Melhor horário para retornar a ligação (opcional)</div>
               </div>
             </fieldset>
@@ -62,21 +62,21 @@
             <fieldset style="border: 1px solid var(--border-light); border-radius: var(--radius); padding: 1.5rem; margin-bottom: 2rem;">
               <legend style="padding: 0 0.5rem; font-weight: 600; color: var(--text-primary);">📝 Conteúdo do Recado</legend>
               <div class="form-group">
-                <label for="assunto" class="form-label required">Assunto</label>
-                <input id="assunto" name="assunto" type="text" class="form-input" placeholder="Resumo do motivo da ligação" required data-label="Assunto" autocomplete="off" />
+                <label for="subject" class="form-label required">Assunto</label>
+                <input id="subject" name="subject" type="text" class="form-input" placeholder="Resumo do motivo da ligação" required data-label="Assunto" autocomplete="off" />
                 <div class="form-help">Descreva brevemente o motivo da ligação</div>
               </div>
               <div class="form-group">
-                <label for="observacoes" class="form-label">Observações</label>
-                <textarea id="observacoes" name="observacoes" class="form-textarea" rows="4" placeholder="Detalhes adicionais, contexto ou informações importantes sobre o recado..." autocomplete="off"></textarea>
+                <label for="notes" class="form-label">Observações</label>
+                <textarea id="notes" name="notes" class="form-textarea" rows="4" placeholder="Detalhes adicionais, contexto ou informações importantes sobre o recado..." autocomplete="off"></textarea>
                 <div class="form-help">Informações adicionais que possam ser úteis (opcional)</div>
               </div>
               <div class="form-group">
-                <label for="situacao" class="form-label">Situação</label>
-                <select id="situacao" name="situacao" class="form-select" autocomplete="off">
-                  <option value="pendente">Pendente</option>
-                  <option value="em_andamento">Em Andamento</option>
-                  <option value="resolvido">Resolvido</option>
+                <label for="status" class="form-label">Situação</label>
+                <select id="status" name="status" class="form-select" autocomplete="off">
+                  <option value="pending">Pendente</option>
+                  <option value="in_progress">Em Andamento</option>
+                  <option value="resolved">Resolvido</option>
                 </select>
                 <div class="form-help">Status atual do recado</div>
               </div>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -43,16 +43,16 @@
             </div>
             <div class="card-body">
                 <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1rem;">
-                    <a href="/recados?situacao=pendente" class="btn btn-warning">
+                    <a href="/recados?status=pending" class="btn btn-warning">
                         <span aria-hidden="true">⏳</span> Pendentes
                     </a>
-                    <a href="/recados?situacao=em_andamento" class="btn btn-primary">
+                    <a href="/recados?status=in_progress" class="btn btn-primary">
                         <span aria-hidden="true">🔄</span> Em Andamento
                     </a>
-                    <a href="/recados?data_inicio=&data_fim=" class="btn btn-outline" id="btnHoje">
+                    <a href="/recados?start_date=&end_date=" class="btn btn-outline" id="btnHoje">
                         <span aria-hidden="true">📅</span> Hoje
                     </a>
-                    <a href="/recados?data_inicio=&data_fim=" class="btn btn-outline" id="btnSemana">
+                    <a href="/recados?start_date=&end_date=" class="btn btn-outline" id="btnSemana">
                         <span aria-hidden="true">📊</span> Esta Semana
                     </a>
                 </div>

--- a/views/novo-recado.ejs
+++ b/views/novo-recado.ejs
@@ -19,17 +19,17 @@
                           <legend style="padding: 0 0.5rem; font-weight: 600; color: var(--text-primary);">📞 Dados da Ligação</legend>
                           <div class="form-grid-2">
                               <div class="form-group">
-                                  <label for="data_ligacao" class="form-label required">Data da Ligação</label>
-                                  <input id="data_ligacao" name="data_ligacao" type="date" class="form-input" required data-label="Data da ligação" autocomplete="bday" />
+                                  <label for="call_date" class="form-label required">Data da Ligação</label>
+                                  <input id="call_date" name="call_date" type="date" class="form-input" required data-label="Data da ligação" autocomplete="bday" />
                               </div>
                               <div class="form-group">
-                                  <label for="hora_ligacao" class="form-label required">Hora da Ligação</label>
-                                  <input id="hora_ligacao" name="hora_ligacao" type="time" class="form-input" required data-label="Hora da ligação" autocomplete="off" />
+                                  <label for="call_time" class="form-label required">Hora da Ligação</label>
+                                  <input id="call_time" name="call_time" type="time" class="form-input" required data-label="Hora da ligação" autocomplete="off" />
                               </div>
                           </div>
                           <div class="form-group">
-                              <label for="destinatario" class="form-label required">Destinatário</label>
-                              <input id="destinatario" name="destinatario" type="text" class="form-input" placeholder="Nome da pessoa ou setor que deve receber o recado" required data-label="Destinatário" autocomplete="organization" />
+                              <label for="recipient" class="form-label required">Destinatário</label>
+                              <input id="recipient" name="recipient" type="text" class="form-input" placeholder="Nome da pessoa ou setor que deve receber o recado" required data-label="Destinatário" autocomplete="organization" />
                               <div class="form-help">Pessoa ou setor responsável por receber esta mensagem</div>
                           </div>
                       </fieldset>
@@ -37,24 +37,24 @@
                       <fieldset style="border: 1px solid var(--border-light); border-radius: var(--radius); padding: 1.5rem; margin-bottom: 2rem;">
                           <legend style="padding: 0 0.5rem; font-weight: 600; color: var(--text-primary);">👤 Dados do Remetente</legend>
                           <div class="form-group">
-                              <label for="remetente_nome" class="form-label required">Nome do Remetente</label>
-                              <input id="remetente_nome" name="remetente_nome" type="text" class="form-input" placeholder="Nome completo de quem ligou" required data-label="Nome do remetente" autocomplete="name" />
+                              <label for="sender_name" class="form-label required">Nome do Remetente</label>
+                              <input id="sender_name" name="sender_name" type="text" class="form-input" placeholder="Nome completo de quem ligou" required data-label="Nome do remetente" autocomplete="name" />
                           </div>
                           <div class="form-grid-2">
                               <div class="form-group">
-                                  <label for="remetente_telefone" class="form-label">Telefone</label>
-                                  <input id="remetente_telefone" name="remetente_telefone" type="tel" class="form-input" placeholder="(11) 99999-9999" autocomplete="tel" />
+                                  <label for="sender_phone" class="form-label">Telefone</label>
+                                  <input id="sender_phone" name="sender_phone" type="tel" class="form-input" placeholder="(11) 99999-9999" autocomplete="tel" />
                                   <div class="form-help">Telefone para retorno (opcional)</div>
                               </div>
                               <div class="form-group">
-                                  <label for="remetente_email" class="form-label">E-mail</label>
-                                  <input id="remetente_email" name="remetente_email" type="email" class="form-input" placeholder="email@exemplo.com" autocomplete="email" />
+                                  <label for="sender_email" class="form-label">E-mail</label>
+                                  <input id="sender_email" name="sender_email" type="email" class="form-input" placeholder="email@exemplo.com" autocomplete="email" />
                                   <div class="form-help">E-mail para contato (opcional)</div>
                               </div>
                           </div>
                           <div class="form-group">
-                              <label for="horario_retorno" class="form-label">Horário para Retorno</label>
-                              <input id="horario_retorno" name="horario_retorno" type="text" class="form-input" placeholder="Ex: Das 9h às 17h, Após 14h, etc." autocomplete="off" />
+                              <label for="callback_time" class="form-label">Horário para Retorno</label>
+                              <input id="callback_time" name="callback_time" type="text" class="form-input" placeholder="Ex: Das 9h às 17h, Após 14h, etc." autocomplete="off" />
                               <div class="form-help">Melhor horário para retornar a ligação (opcional)</div>
                           </div>
                       </fieldset>
@@ -62,21 +62,21 @@
                       <fieldset style="border: 1px solid var(--border-light); border-radius: var(--radius); padding: 1.5rem; margin-bottom: 2rem;">
                           <legend style="padding: 0 0.5rem; font-weight: 600; color: var(--text-primary);">📝 Conteúdo do Recado</legend>
                           <div class="form-group">
-                              <label for="assunto" class="form-label required">Assunto</label>
-                              <input id="assunto" name="assunto" type="text" class="form-input" placeholder="Resumo do motivo da ligação" required data-label="Assunto" autocomplete="off" />
+                              <label for="subject" class="form-label required">Assunto</label>
+                              <input id="subject" name="subject" type="text" class="form-input" placeholder="Resumo do motivo da ligação" required data-label="Assunto" autocomplete="off" />
                               <div class="form-help">Descreva brevemente o motivo da ligação</div>
                           </div>
                           <div class="form-group">
-                              <label for="observacoes" class="form-label">Observações</label>
-                              <textarea id="observacoes" name="observacoes" class="form-textarea" rows="4" placeholder="Detalhes adicionais, contexto ou informações importantes sobre o recado..." autocomplete="off"></textarea>
+                              <label for="notes" class="form-label">Observações</label>
+                              <textarea id="notes" name="notes" class="form-textarea" rows="4" placeholder="Detalhes adicionais, contexto ou informações importantes sobre o recado..." autocomplete="off"></textarea>
                               <div class="form-help">Informações adicionais que possam ser úteis (opcional)</div>
                           </div>
                           <div class="form-group">
-                              <label for="situacao" class="form-label">Situação Inicial</label>
-                              <select id="situacao" name="situacao" class="form-select" autocomplete="off">
-                                  <option value="pendente">Pendente</option>
-                                  <option value="em_andamento">Em Andamento</option>
-                                  <option value="resolvido">Resolvido</option>
+                              <label for="status" class="form-label">Situação Inicial</label>
+                              <select id="status" name="status" class="form-select" autocomplete="off">
+                                  <option value="pending">Pendente</option>
+                                  <option value="in_progress">Em Andamento</option>
+                                  <option value="resolved">Resolvido</option>
                               </select>
                               <div class="form-help">Status atual do recado</div>
                           </div>

--- a/views/recados.ejs
+++ b/views/recados.ejs
@@ -15,24 +15,24 @@
                   <form id="filtrosForm">
                       <div class="filters-grid">
                           <div class="form-group">
-                              <label for="data_inicio" class="form-label">Data Início</label>
-                              <input id="data_inicio" name="data_inicio" type="date" class="form-input">
+                              <label for="start_date" class="form-label">Data Início</label>
+                              <input id="start_date" name="start_date" type="date" class="form-input">
                           </div>
                           <div class="form-group">
-                              <label for="data_fim" class="form-label">Data Fim</label>
-                              <input id="data_fim" name="data_fim" type="date" class="form-input">
+                              <label for="end_date" class="form-label">Data Fim</label>
+                              <input id="end_date" name="end_date" type="date" class="form-input">
                           </div>
                           <div class="form-group">
-                              <label for="destinatario" class="form-label">Destinatário</label>
-                              <input id="destinatario" name="destinatario" type="text" class="form-input" placeholder="Nome do destinatário">
+                              <label for="recipient" class="form-label">Destinatário</label>
+                              <input id="recipient" name="recipient" type="text" class="form-input" placeholder="Nome do destinatário">
                           </div>
                           <div class="form-group">
-                              <label for="situacao" class="form-label">Situação</label>
-                              <select id="situacao" name="situacao" class="form-input">
+                              <label for="status" class="form-label">Situação</label>
+                              <select id="status" name="status" class="form-input">
                                   <option value="">Todas</option>
-                                  <option value="pendente">Pendente</option>
-                                  <option value="em_andamento">Em Andamento</option>
-                                  <option value="resolvido">Resolvido</option>
+                                  <option value="pending">Pendente</option>
+                                  <option value="in_progress">Em Andamento</option>
+                                  <option value="resolved">Resolvido</option>
                               </select>
                           </div>
                       </div>


### PR DESCRIPTION
## Summary
- atualiza os formulários EJS para enviar os campos call_date, recipient, notes e status usando os novos atributos em inglês
- ajusta os scripts públicos para consumir /api/messages e trabalhar com as chaves call_*, sender_*, status e notes nas respostas da API
- adapta utilitários e helpers do frontend (API, Normalizer, labels de status) para os novos identificadores mantendo as mensagens em português

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d339c19ec48324bf81e70444010055