### PR TITLE
Fix database helper import to avoid missing module error

### DIFF
--- a/models/message.js
+++ b/models/message.js
@@ -1,4 +1,8 @@
-const db = require('./_db');
+const databaseManager = require('../config/database');
+
+function db() {
+  return databaseManager.getDatabase();
+}
 
 const TABLE = 'messages';
 

--- a/models/user.js
+++ b/models/user.js
@@ -2,7 +2,11 @@
 // User model using DatabaseManager helper (SQLite / ready for PG adapter).
 // Table: users (id, name, email, password_hash, role, is_active, created_at, updated_at)
 
-const db = require('./_db');
+const databaseManager = require('../config/database');
+
+function db() {
+  return databaseManager.getDatabase();
+}
 
 class UserModel {
   constructor() {


### PR DESCRIPTION
## Summary
- replace the message model's database helper require with a direct DatabaseManager call
- update the user model to use the same helper, avoiding the missing `./_db` module at runtime

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d349bd8cec8324a1d51e1b7087187c