### PR TITLE
Add filters to recados listing

### DIFF
--- a/controllers/messageController.js
+++ b/controllers/messageController.js
@@ -43,8 +43,8 @@ function formatMonthLabel(label) {
 
 exports.list = (req, res) => {
   try {
-    const { limit, offset, status } = req.query || {};
-    const messages = MessageModel.list({ limit, offset, status }).map(formatMessage);
+    const { limit, offset, status, start_date, end_date, recipient } = req.query || {};
+    const messages = MessageModel.list({ limit, offset, status, start_date, end_date, recipient }).map(formatMessage);
     return res.json({ success: true, data: messages });
   } catch (err) {
     console.error('[messages] erro ao listar:', err);


### PR DESCRIPTION
## Summary
- wire the recados filter form to serialize inputs and call the messages API with query parameters
- extend the messages controller/model to honor start/end date and recipient filters in addition to status
- allow the API validation middleware to accept and sanitize the new query parameters

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d36079d3d48324a65f7cbd9777bb81