### PR TITLE
Fix message model column detection after lazy table creation

### DIFF
--- a/__tests__/recado.legacy-timestamps.test.js
+++ b/__tests__/recado.legacy-timestamps.test.js
@@ -1,82 +1,170 @@
+process.env.NODE_ENV = 'test';
 process.env.DB_PATH = '';
 
-const dbManager = require('../config/database');
+let dbManager;
 let MessageModel;
 
-beforeEach(() => {
-  dbManager.close();
-  const db = dbManager.getDatabase();
-  db.exec(`
-    CREATE TABLE messages (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      call_date TEXT NOT NULL,
-      call_time TEXT NOT NULL,
-      recipient TEXT NOT NULL,
-      sender_name TEXT NOT NULL,
-      sender_phone TEXT,
-      sender_email TEXT,
-      subject TEXT NOT NULL,
-      message TEXT,
-      status TEXT DEFAULT 'pending',
-      callback_time TEXT,
-      notes TEXT,
-      created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-      updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
-    );
-  `);
-  delete require.cache[require.resolve('../models/message')];
-  MessageModel = require('../models/message');
-});
+const SCHEMAS = [
+  {
+    label: 'modern messages schema',
+    setupSql: `
+      CREATE TABLE messages (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        call_date TEXT NOT NULL,
+        call_time TEXT NOT NULL,
+        recipient TEXT NOT NULL,
+        sender_name TEXT NOT NULL,
+        sender_phone TEXT,
+        sender_email TEXT,
+        subject TEXT NOT NULL,
+        message TEXT,
+        status TEXT DEFAULT 'pending',
+        callback_time TEXT,
+        notes TEXT,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      );
+    `,
+    insertRecentSql: `
+      INSERT INTO messages (call_date, call_time, recipient, sender_name, subject, message, status, created_at, updated_at)
+      VALUES ('2024-01-01','09:00','Dest1','Rem1','A','Mensagem A','pending','2024-01-01 10:00:00','2024-01-01 10:00:00'),
+             ('2024-01-02','10:00','Dest2','Rem2','B','Mensagem B','resolved','2024-01-02 11:00:00','2024-01-02 11:00:00');
+    `,
+  },
+  {
+    label: 'legacy recados schema',
+    setupSql: `
+      CREATE TABLE recados (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        data_ligacao TEXT NOT NULL,
+        hora_ligacao TEXT NOT NULL,
+        destinatario TEXT NOT NULL,
+        remetente_nome TEXT NOT NULL,
+        remetente_telefone TEXT,
+        remetente_email TEXT,
+        assunto TEXT NOT NULL,
+        mensagem TEXT NOT NULL,
+        situacao TEXT DEFAULT 'pendente',
+        horario_retorno TEXT,
+        observacoes TEXT,
+        criado_em DATETIME DEFAULT CURRENT_TIMESTAMP,
+        atualizado_em DATETIME DEFAULT CURRENT_TIMESTAMP
+      );
+    `,
+    insertRecentSql: `
+      INSERT INTO recados (data_ligacao, hora_ligacao, destinatario, remetente_nome, assunto, mensagem, situacao, horario_retorno, observacoes, criado_em, atualizado_em)
+      VALUES ('2024-01-01','09:00','Dest1','Rem1','A','Mensagem A','pendente','Manhã','Obs A','2024-01-01 10:00:00','2024-01-01 10:00:00'),
+             ('2024-01-02','10:00','Dest2','Rem2','B','Mensagem B','resolvido','Tarde','Obs B','2024-01-02 11:00:00','2024-01-02 11:00:00');
+    `,
+  },
+  {
+    label: 'modern recados schema created after import',
+    setupSql: `
+      CREATE TABLE recados (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        call_date TEXT NOT NULL,
+        call_time TEXT NOT NULL,
+        recipient TEXT NOT NULL,
+        sender_name TEXT NOT NULL,
+        sender_phone TEXT,
+        sender_email TEXT,
+        subject TEXT NOT NULL,
+        message TEXT,
+        status TEXT DEFAULT 'pending',
+        callback_time TEXT,
+        notes TEXT,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      );
+    `,
+    insertRecentSql: `
+      INSERT INTO recados (call_date, call_time, recipient, sender_name, subject, message, status, created_at, updated_at)
+      VALUES ('2024-01-01','09:00','Dest1','Rem1','A','Mensagem A','pending','2024-01-01 10:00:00','2024-01-01 10:00:00'),
+             ('2024-01-02','10:00','Dest2','Rem2','B','Mensagem B','resolved','2024-01-02 11:00:00','2024-01-02 11:00:00');
+    `,
+    createAfterImport: true,
+  },
+];
 
-afterEach(() => {
-  dbManager.close();
-});
-
-test('CRUD operations work with timestamp columns', () => {
-  const id = MessageModel.create({
-    call_date: '2024-03-01',
-    call_time: '08:00',
-    recipient: 'Alice',
-    sender_name: 'Bob',
-    subject: 'Teste',
-    message: 'Mensagem de teste'
+describe.each(SCHEMAS)('$label', schema => {
+  beforeEach(() => {
+    jest.resetModules();
+    dbManager = require('../config/database');
+    dbManager.close();
+    const db = dbManager.getDatabase();
+    db.exec(`
+      DROP TABLE IF EXISTS messages;
+      DROP TABLE IF EXISTS recados;
+    `);
+    if (!schema.createAfterImport) {
+      db.exec(schema.setupSql);
+    }
+    MessageModel = require('../models/message');
+    if (schema.createAfterImport) {
+      db.exec(schema.setupSql);
+    }
   });
-  expect(typeof id).toBe('number');
 
-  const fetched = MessageModel.findById(id);
-  expect(fetched.recipient).toBe('Alice');
-  expect(fetched.status).toBe('pending');
-
-  const updatedOk = MessageModel.update(id, {
-    call_date: '2024-03-01',
-    call_time: '09:15',
-    recipient: 'Alice',
-    sender_name: 'Bob',
-    subject: 'Teste',
-    message: 'Mensagem atualizada',
-    status: 'resolved'
+  afterEach(() => {
+    dbManager.close();
   });
-  expect(updatedOk).toBe(true);
 
-  const updated = MessageModel.findById(id);
-  expect(updated.status).toBe('resolved');
+  test('CRUD operations work with timestamp columns', () => {
+    const id = MessageModel.create({
+      call_date: '2024-03-01',
+      call_time: '08:00',
+      recipient: 'Alice',
+      sender_name: 'Bob',
+      sender_phone: '(11) 99999-9999',
+      sender_email: 'bob@example.com',
+      subject: 'Teste',
+      message: 'Mensagem de teste',
+      callback_time: 'Após 12h',
+      notes: 'Observações iniciais'
+    });
+    expect(typeof id).toBe('number');
 
-  const removed = MessageModel.remove(id);
-  expect(removed).toBe(true);
-  expect(MessageModel.findById(id)).toBeNull();
-});
+    const fetched = MessageModel.findById(id);
+    expect(fetched.recipient).toBe('Alice');
+    expect(fetched.message).toBe('Mensagem de teste');
+    expect(fetched.callback_time).toBe('Após 12h');
+    expect(fetched.notes).toBe('Observações iniciais');
+    expect(fetched.status).toBe('pending');
 
-test('list keeps newest first with timestamps', () => {
-  const db = dbManager.getDatabase();
-  db.exec(`
-    INSERT INTO messages (call_date, call_time, recipient, sender_name, subject, message, status, created_at, updated_at)
-    VALUES ('2024-01-01','09:00','Dest1','Rem1','A','Mensagem A','pending','2024-01-01 10:00:00','2024-01-01 10:00:00'),
-           ('2024-01-02','10:00','Dest2','Rem2','B','Mensagem B','resolved','2024-01-02 11:00:00','2024-01-02 11:00:00');
-  `);
+    const updatedOk = MessageModel.update(id, {
+      call_date: '2024-03-01',
+      call_time: '09:15',
+      recipient: 'Alice',
+      sender_name: 'Bob',
+      sender_phone: '(11) 98888-7777',
+      sender_email: 'bob@update.com',
+      subject: 'Teste',
+      message: 'Mensagem atualizada',
+      callback_time: 'Após 18h',
+      notes: 'Observações atualizadas',
+      status: 'resolved'
+    });
+    expect(updatedOk).toBe(true);
 
-  const list = MessageModel.list({ limit: 5 });
-  const subjects = list.map(item => item.subject);
-  expect(subjects).toEqual(['B', 'A']);
-  expect(list[0].status).toBe('resolved');
-  expect(list[1].status).toBe('pending');
+    const updated = MessageModel.findById(id);
+    expect(updated.status).toBe('resolved');
+    expect(updated.message).toBe('Mensagem atualizada');
+    expect(updated.callback_time).toBe('Após 18h');
+    expect(updated.notes).toBe('Observações atualizadas');
+
+    const removed = MessageModel.remove(id);
+    expect(removed).toBe(true);
+    expect(MessageModel.findById(id)).toBeNull();
+  });
+
+  test('list keeps newest first with timestamps', () => {
+    const db = dbManager.getDatabase();
+    db.exec(schema.insertRecentSql);
+
+    const list = MessageModel.list({ limit: 5 });
+    const subjects = list.map(item => item.subject);
+    expect(subjects).toEqual(['B', 'A']);
+    expect(list[0].status).toBe('resolved');
+    expect(list[1].status).toBe('pending');
+  });
 });

--- a/__tests__/recado.legacy-timestamps.test.js
+++ b/__tests__/recado.legacy-timestamps.test.js
@@ -167,4 +167,18 @@ describe.each(SCHEMAS)('$label', schema => {
     expect(list[0].status).toBe('resolved');
     expect(list[1].status).toBe('pending');
   });
+
+  test('stats aggregates counts per status across schemas', () => {
+    const db = dbManager.getDatabase();
+    db.exec(schema.insertRecentSql);
+
+    const summary = MessageModel.stats();
+
+    expect(summary).toEqual({
+      total: 2,
+      pending: 1,
+      in_progress: 0,
+      resolved: 1,
+    });
+  });
 });

--- a/models/message.js
+++ b/models/message.js
@@ -15,16 +15,273 @@ function resolveMessageTable() {
 
     for (const tableName of MESSAGE_TABLE_CANDIDATES) {
       const found = statement.get({ table: tableName });
-      if (found && found.name) return found.name;
+      if (found && found.name) {
+        return { name: found.name, confirmed: true };
+      }
     }
   } catch (err) {
     console.warn('[message:model] Falha ao resolver tabela de recados:', err.message);
   }
 
-  return 'recados';
+  return { name: 'recados', confirmed: false };
 }
 
-const TABLE = resolveMessageTable();
+const COLUMN_MAPS = {
+  modern: {
+    id: 'id',
+    call_date: 'call_date',
+    call_time: 'call_time',
+    recipient: 'recipient',
+    sender_name: 'sender_name',
+    sender_phone: 'sender_phone',
+    sender_email: 'sender_email',
+    subject: 'subject',
+    message: 'message',
+    status: 'status',
+    callback_time: 'callback_time',
+    notes: 'notes',
+    created_at: 'created_at',
+    updated_at: 'updated_at',
+  },
+  legacy: {
+    id: 'id',
+    call_date: 'data_ligacao',
+    call_time: 'hora_ligacao',
+    recipient: 'destinatario',
+    sender_name: 'remetente_nome',
+    sender_phone: 'remetente_telefone',
+    sender_email: 'remetente_email',
+    subject: 'assunto',
+    message: 'mensagem',
+    status: 'situacao',
+    callback_time: 'horario_retorno',
+    notes: 'observacoes',
+    created_at: 'criado_em',
+    updated_at: 'atualizado_em',
+  },
+};
+
+function resolveColumnMap(tableName) {
+  const fallbackSchema = tableName === 'recados' ? 'legacy' : 'modern';
+
+  try {
+    const database = db();
+    const pragmaStatement = database.prepare(`PRAGMA table_info(${JSON.stringify(tableName)})`);
+    const columnsInfo = pragmaStatement.all();
+
+    if (!columnsInfo || columnsInfo.length === 0) {
+      return { schema: fallbackSchema, map: COLUMN_MAPS[fallbackSchema], confirmed: false };
+    }
+
+    const columnNames = new Set(columnsInfo.map(column => column.name));
+
+    const isLegacy = ['situacao', 'data_ligacao', 'mensagem'].some(name => columnNames.has(name));
+    if (isLegacy) {
+      return { schema: 'legacy', map: COLUMN_MAPS.legacy, confirmed: true };
+    }
+
+    const looksModern = ['call_date', 'message', 'notes'].every(name => columnNames.has(name));
+    if (looksModern) {
+      return { schema: 'modern', map: COLUMN_MAPS.modern, confirmed: true };
+    }
+
+    return { schema: fallbackSchema, map: COLUMN_MAPS[fallbackSchema], confirmed: false };
+  } catch (err) {
+    console.warn(
+      `[message:model] Falha ao inspecionar colunas da tabela ${tableName}:`,
+      err.message
+    );
+  }
+
+  return { schema: fallbackSchema, map: COLUMN_MAPS[fallbackSchema], confirmed: false };
+}
+
+const SELECTABLE_FIELDS = [
+  'id',
+  'call_date',
+  'call_time',
+  'recipient',
+  'sender_name',
+  'sender_phone',
+  'sender_email',
+  'subject',
+  'message',
+  'status',
+  'callback_time',
+  'notes',
+  'created_at',
+  'updated_at',
+];
+
+const INSERT_FIELDS = [
+  'call_date',
+  'call_time',
+  'recipient',
+  'sender_name',
+  'sender_phone',
+  'sender_email',
+  'subject',
+  'message',
+  'status',
+  'callback_time',
+  'notes',
+  'created_at',
+  'updated_at',
+];
+
+function defaultTableState() {
+  return { name: 'recados', confirmed: false };
+}
+
+function defaultColumnState() {
+  return { schema: 'modern', map: COLUMN_MAPS.modern, confirmed: false };
+}
+
+let tableState = defaultTableState();
+let columnState = defaultColumnState();
+let sqlCache = null;
+let legacyMigrationPending = true;
+
+function resetRuntime() {
+  tableState = defaultTableState();
+  columnState = defaultColumnState();
+  sqlCache = null;
+  legacyMigrationPending = true;
+}
+
+function ensureTable() {
+  if (!tableState.confirmed) {
+    const resolved = resolveMessageTable();
+    const tableChanged = tableState.name !== resolved.name;
+    tableState = resolved;
+    if (tableChanged) {
+      columnState = defaultColumnState();
+      sqlCache = null;
+    }
+  }
+  return tableState;
+}
+
+function ensureColumnConfig() {
+  const { name: tableName } = ensureTable();
+  if (!columnState.confirmed) {
+    const resolved = resolveColumnMap(tableName);
+    const mapChanged = columnState.map !== resolved.map;
+    columnState = resolved;
+    if (mapChanged) {
+      sqlCache = null;
+    }
+  }
+  return columnState;
+}
+
+function buildSqlCache(map) {
+  const column = name => map[name] || name;
+  return {
+    map,
+    selectColumns: SELECTABLE_FIELDS.map(field => {
+      const mapped = column(field);
+      return mapped === field ? mapped : `${mapped} AS ${field}`;
+    }).join(',\n      '),
+    insertColumns: INSERT_FIELDS.map(column).join(',\n      '),
+    insertValues: INSERT_FIELDS.map(field => {
+      if (field === 'created_at' || field === 'updated_at') {
+        return `COALESCE(@${field}, datetime('now'))`;
+      }
+      return `@${field}`;
+    }).join(',\n      '),
+    statusColumn: column('status'),
+    idColumn: column('id'),
+  };
+}
+
+function getRuntime() {
+  const tableInfo = ensureTable();
+  const columnInfo = ensureColumnConfig();
+
+  if (!sqlCache || sqlCache.map !== columnInfo.map) {
+    sqlCache = buildSqlCache(columnInfo.map);
+  }
+
+  const column = name => columnInfo.map[name] || name;
+
+  return {
+    table: tableInfo.name,
+    schema: columnInfo.schema,
+    confirmed: tableInfo.confirmed && columnInfo.confirmed,
+    column,
+    selectColumns: sqlCache.selectColumns,
+    insertColumns: sqlCache.insertColumns,
+    insertValues: sqlCache.insertValues,
+    statusColumn: sqlCache.statusColumn,
+    idColumn: sqlCache.idColumn,
+  };
+}
+
+function shouldRetryError(err) {
+  if (!err || typeof err.message !== 'string') return false;
+  return /no such table/i.test(err.message) || /no column/i.test(err.message);
+}
+
+function attemptLegacyMigration(runtime) {
+  if (!legacyMigrationPending || !runtime.confirmed) return;
+
+  try {
+    const database = db();
+    const exists = database
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=@table LIMIT 1")
+      .get({ table: runtime.table });
+
+    if (!exists) {
+      return;
+    }
+
+    const updates = [
+      { from: 'pendente', to: 'pending' },
+      { from: 'em_andamento', to: 'in_progress' },
+      { from: 'resolvido', to: 'resolved' },
+    ];
+
+    const updateStmt = database.prepare(`
+      UPDATE ${runtime.table}
+         SET ${runtime.statusColumn} = @to
+       WHERE ${runtime.statusColumn} = @from
+    `);
+
+    for (const pair of updates) {
+      updateStmt.run(pair);
+    }
+  } catch (err) {
+    console.warn('[message:model] Falha ao migrar status legados:', err.message);
+  } finally {
+    legacyMigrationPending = false;
+  }
+}
+
+function withRuntime(callback) {
+  let lastError;
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    if (attempt === 1) {
+      resetRuntime();
+    }
+
+    const runtime = getRuntime();
+    attemptLegacyMigration(runtime);
+
+    try {
+      return callback(runtime);
+    } catch (err) {
+      lastError = err;
+      if (attempt === 0 && shouldRetryError(err)) {
+        continue;
+      }
+      throw err;
+    }
+  }
+
+  throw lastError;
+}
 
 const STATUS_EN_TO_PT = {
   pending: 'pendente',
@@ -130,33 +387,6 @@ function mapRow(row) {
   };
 }
 
-function migrateLegacyStatuses() {
-  const database = db();
-  try {
-    const statement = database.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name=@table LIMIT 1`);
-    const exists = statement.get({ table: TABLE });
-    if (!exists) return;
-
-    const updates = [
-      { from: 'pendente', to: 'pending' },
-      { from: 'em_andamento', to: 'in_progress' },
-      { from: 'resolvido', to: 'resolved' },
-    ];
-
-    const updateStmt = database.prepare(`
-      UPDATE ${TABLE}
-         SET status = @to
-       WHERE status = @from
-    `);
-
-    for (const pair of updates) {
-      updateStmt.run(pair);
-    }
-  } catch (err) {
-    console.warn('[message:model] Falha ao migrar status legados:', err.message);
-  }
-}
-
 function ensureStatus(value) {
   const normalized = normalizeStatus(value);
   return STATUS_VALUES.includes(normalized) ? normalized : 'pending';
@@ -179,155 +409,130 @@ function attachTimestamps(payload, source = {}) {
   return { ...payload, ...timestamps };
 }
 
-function selectBase(whereClause = '', orderClause = 'ORDER BY id DESC', limitClause = 'LIMIT @limit OFFSET @offset') {
+function selectBase(
+  runtime,
+  whereClause = '',
+  orderClause,
+  limitClause = 'LIMIT @limit OFFSET @offset'
+) {
+  const orderSegment = orderClause || `ORDER BY ${runtime.idColumn} DESC`;
   return `
     SELECT
-      id,
-      call_date,
-      call_time,
-      recipient,
-      sender_name,
-      sender_phone,
-      sender_email,
-      subject,
-      message,
-      status,
-      callback_time,
-      notes,
-      created_at,
-      updated_at
-      FROM ${TABLE}
+      ${runtime.selectColumns}
+      FROM ${runtime.table}
       ${whereClause}
-      ${orderClause}
+      ${orderSegment}
       ${limitClause}
   `;
 }
 
 function create(payload) {
-  const normalizedPayload = normalizePayload(payload);
-  const timestamps = attachTimestamps({}, payload);
-  const data = {
-    ...normalizedPayload.data,
-    status: normalizedPayload.statusProvided && normalizedPayload.data.status
-      ? normalizedPayload.data.status
-      : 'pending',
-  };
-  const info = db().prepare(`
-    INSERT INTO ${TABLE} (
-      call_date,
-      call_time,
-      recipient,
-      sender_name,
-      sender_phone,
-      sender_email,
-      subject,
-      message,
-      status,
-      callback_time,
-      notes,
-      created_at,
-      updated_at
-    ) VALUES (
-      @call_date,
-      @call_time,
-      @recipient,
-      @sender_name,
-      @sender_phone,
-      @sender_email,
-      @subject,
-      @message,
-      @status,
-      @callback_time,
-      @notes,
-      COALESCE(@created_at, datetime('now')),
-      COALESCE(@updated_at, datetime('now'))
-    )
-  `).run({ ...data, ...timestamps });
+  return withRuntime(runtime => {
+    const normalizedPayload = normalizePayload(payload);
+    const timestamps = attachTimestamps({}, payload);
+    const data = {
+      ...normalizedPayload.data,
+      status: normalizedPayload.statusProvided && normalizedPayload.data.status
+        ? normalizedPayload.data.status
+        : 'pending',
+    };
 
-  return info.lastInsertRowid;
+    const info = db().prepare(`
+      INSERT INTO ${runtime.table} (
+        ${runtime.insertColumns}
+      ) VALUES (
+        ${runtime.insertValues}
+      )
+    `).run({ ...data, ...timestamps });
+
+    return info.lastInsertRowid;
+  });
 }
 
 function findById(id) {
-  const row = db().prepare(`
-    SELECT
-      id,
-      call_date,
-      call_time,
-      recipient,
-      sender_name,
-      sender_phone,
-      sender_email,
-      subject,
-      message,
-      status,
-      callback_time,
-      notes,
-      created_at,
-      updated_at
-      FROM ${TABLE}
-     WHERE id = @id
-  `).get({ id });
-  return mapRow(row);
+  return withRuntime(runtime => {
+    const row = db().prepare(`
+      SELECT
+        ${runtime.selectColumns}
+        FROM ${runtime.table}
+       WHERE ${runtime.idColumn} = @id
+       LIMIT 1
+    `).get({ id });
+    return mapRow(row);
+  });
 }
 
 function update(id, payload) {
-  const normalizedPayload = normalizePayload(payload);
-  const info = db().prepare(`
-    UPDATE ${TABLE}
-       SET call_date     = @call_date,
-           call_time     = @call_time,
-           recipient     = @recipient,
-           sender_name   = @sender_name,
-           sender_phone  = @sender_phone,
-           sender_email  = @sender_email,
-           subject       = @subject,
-           message       = @message,
-           status        = COALESCE(@status, status),
-           callback_time = @callback_time,
-           notes         = @notes,
-           updated_at    = datetime('now')
-     WHERE id = @id
-  `).run({ id, ...normalizedPayload.data, status: normalizedPayload.statusProvided ? normalizedPayload.data.status : null });
+  return withRuntime(runtime => {
+    const normalizedPayload = normalizePayload(payload);
+    const info = db().prepare(`
+      UPDATE ${runtime.table}
+         SET ${runtime.column('call_date')}     = @call_date,
+             ${runtime.column('call_time')}     = @call_time,
+             ${runtime.column('recipient')}     = @recipient,
+             ${runtime.column('sender_name')}   = @sender_name,
+             ${runtime.column('sender_phone')}  = @sender_phone,
+             ${runtime.column('sender_email')}  = @sender_email,
+             ${runtime.column('subject')}       = @subject,
+             ${runtime.column('message')}       = @message,
+             ${runtime.statusColumn}           = COALESCE(@status, ${runtime.statusColumn}),
+             ${runtime.column('callback_time')} = @callback_time,
+             ${runtime.column('notes')}         = @notes,
+             ${runtime.column('updated_at')}    = datetime('now')
+       WHERE ${runtime.idColumn} = @id
+    `).run({
+      id,
+      ...normalizedPayload.data,
+      status: normalizedPayload.statusProvided ? normalizedPayload.data.status : null,
+    });
 
-  return info.changes > 0;
+    return info.changes > 0;
+  });
 }
 
 function updateStatus(id, status) {
-  const normalized = ensureStatus(status);
-  const info = db().prepare(`
-    UPDATE ${TABLE}
-       SET status = @status,
-           updated_at = datetime('now')
-     WHERE id = @id
-  `).run({ id, status: normalized });
-  return info.changes > 0;
+  return withRuntime(runtime => {
+    const normalized = ensureStatus(status);
+    const info = db().prepare(`
+      UPDATE ${runtime.table}
+         SET ${runtime.statusColumn}        = @status,
+             ${runtime.column('updated_at')} = datetime('now')
+       WHERE ${runtime.idColumn} = @id
+    `).run({ id, status: normalized });
+    return info.changes > 0;
+  });
 }
 
 function remove(id) {
-  const info = db().prepare(`DELETE FROM ${TABLE} WHERE id = @id`).run({ id });
-  return info.changes > 0;
+  return withRuntime(runtime => {
+    const info = db().prepare(`DELETE FROM ${runtime.table} WHERE ${runtime.idColumn} = @id`).run({ id });
+    return info.changes > 0;
+  });
 }
 
 function list({ limit = 10, offset = 0, status } = {}) {
-  const parsedLimit = Number(limit);
-  const parsedOffset = Number(offset);
-  const sanitizedLimit = Number.isFinite(parsedLimit) && parsedLimit > 0 ? Math.min(parsedLimit, 200) : 10;
-  const sanitizedOffset = Number.isFinite(parsedOffset) && parsedOffset >= 0 ? parsedOffset : 0;
-  const statusFilter = translateStatusForQuery(status);
+  return withRuntime(runtime => {
+    const parsedLimit = Number(limit);
+    const parsedOffset = Number(offset);
+    const sanitizedLimit = Number.isFinite(parsedLimit) && parsedLimit > 0 ? Math.min(parsedLimit, 200) : 10;
+    const sanitizedOffset = Number.isFinite(parsedOffset) && parsedOffset >= 0 ? parsedOffset : 0;
+    const statusFilter = translateStatusForQuery(status);
 
-  let whereClause = '';
-  if (statusFilter) {
-    whereClause = 'WHERE status IN (@status, @legacy)';
-  }
+    let whereClause = '';
+    if (statusFilter) {
+      whereClause = `WHERE ${runtime.statusColumn} IN (@status, @legacy)`;
+    }
 
-  const query = selectBase(whereClause);
-  const rows = db().prepare(query).all({
-    limit: sanitizedLimit,
-    offset: sanitizedOffset,
-    status: statusFilter ? statusFilter.current : undefined,
-    legacy: statusFilter ? statusFilter.legacy : undefined,
+    const query = selectBase(runtime, whereClause);
+    const rows = db().prepare(query).all({
+      limit: sanitizedLimit,
+      offset: sanitizedOffset,
+      status: statusFilter ? statusFilter.current : undefined,
+      legacy: statusFilter ? statusFilter.legacy : undefined,
+    });
+
+    return rows.map(mapRow);
   });
-  return rows.map(mapRow);
 }
 
 function listRecent(limit = 10) {
@@ -335,26 +540,32 @@ function listRecent(limit = 10) {
 }
 
 function stats() {
-  const database = db();
-  const total = database.prepare(`SELECT COUNT(*) AS count FROM ${TABLE}`).get().count;
+  return withRuntime(runtime => {
+    const database = db();
+    const total = database.prepare(`SELECT COUNT(*) AS count FROM ${runtime.table}`).get().count;
 
-  const counters = {};
-  for (const status of STATUS_VALUES) {
-    const legacy = STATUS_EN_TO_PT[status];
-    const row = database.prepare(`
-      SELECT COUNT(*) AS count
-        FROM ${TABLE}
-       WHERE status IN (@status, @legacy)
-    `).get({ status, legacy });
-    counters[status] = row.count;
-  }
+    const counters = {};
+    for (const status of STATUS_VALUES) {
+      const legacy = STATUS_EN_TO_PT[status];
+      const row = database.prepare(`
+        SELECT COUNT(*) AS count
+          FROM ${runtime.table}
+         WHERE ${runtime.statusColumn} IN (@status, @legacy)
+      `).get({ status, legacy });
+      counters[status] = row.count;
+    }
 
-  return {
-    total,
-    pending: counters.pending || 0,
-    in_progress: counters.in_progress || 0,
-    resolved: counters.resolved || 0,
-  };
+    return {
+      total,
+      pending: counters.pending || 0,
+      in_progress: counters.in_progress || 0,
+      resolved: counters.resolved || 0,
+    };
+  });
+}
+
+function migrateLegacyStatuses() {
+  withRuntime(() => {});
 }
 
 migrateLegacyStatuses();


### PR DESCRIPTION
## Summary
- lazily resolve the message table and column map so SQL snippets rebuild after the backing schema appears and retry after transient column errors
- guard the legacy status migration behind the dynamic runtime context and reuse the new query helpers for CRUD/list/stats operations
- extend the message model tests with a recados table that is created after the model import to prove the modern column layout is detected

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d350047d648324a43b2f86fa026fed