### PR TITLE
Improve message model table and column resolution

### DIFF
--- a/models/message.js
+++ b/models/message.js
@@ -15,16 +15,16 @@ function resolveMessageTable() {
 
     for (const tableName of MESSAGE_TABLE_CANDIDATES) {
       const found = statement.get({ table: tableName });
-      if (found && found.name) return found.name;
+      if (found && found.name) {
+        return { name: found.name, confirmed: true };
+      }
     }
   } catch (err) {
     console.warn('[message:model] Falha ao resolver tabela de recados:', err.message);
   }
 
-  return 'recados';
+  return { name: 'recados', confirmed: false };
 }
-
-const TABLE = resolveMessageTable();
 
 const COLUMN_MAPS = {
   modern: {
@@ -62,25 +62,30 @@ const COLUMN_MAPS = {
 };
 
 function resolveColumnMap(tableName) {
+  const fallbackSchema = tableName === 'recados' ? 'legacy' : 'modern';
+
   try {
     const database = db();
     const pragmaStatement = database.prepare(`PRAGMA table_info(${JSON.stringify(tableName)})`);
     const columnsInfo = pragmaStatement.all();
+
+    if (!columnsInfo || columnsInfo.length === 0) {
+      return { schema: fallbackSchema, map: COLUMN_MAPS[fallbackSchema], confirmed: false };
+    }
+
     const columnNames = new Set(columnsInfo.map(column => column.name));
 
     const isLegacy = ['situacao', 'data_ligacao', 'mensagem'].some(name => columnNames.has(name));
     if (isLegacy) {
-      return { schema: 'legacy', map: COLUMN_MAPS.legacy };
+      return { schema: 'legacy', map: COLUMN_MAPS.legacy, confirmed: true };
     }
 
     const looksModern = ['call_date', 'message', 'notes'].every(name => columnNames.has(name));
     if (looksModern) {
-      return { schema: 'modern', map: COLUMN_MAPS.modern };
+      return { schema: 'modern', map: COLUMN_MAPS.modern, confirmed: true };
     }
 
-    if (tableName === 'recados') {
-      return { schema: 'legacy', map: COLUMN_MAPS.legacy };
-    }
+    return { schema: fallbackSchema, map: COLUMN_MAPS[fallbackSchema], confirmed: false };
   } catch (err) {
     console.warn(
       `[message:model] Falha ao inspecionar colunas da tabela ${tableName}:`,
@@ -88,14 +93,7 @@ function resolveColumnMap(tableName) {
     );
   }
 
-  return { schema: 'modern', map: COLUMN_MAPS.modern };
-}
-
-const COLUMN_CONFIG = resolveColumnMap(TABLE);
-const COLUMN_MAP = COLUMN_CONFIG.map;
-
-function column(name) {
-  return COLUMN_MAP[name] || name;
+  return { schema: fallbackSchema, map: COLUMN_MAPS[fallbackSchema], confirmed: false };
 }
 
 const SELECTABLE_FIELDS = [
@@ -131,25 +129,165 @@ const INSERT_FIELDS = [
   'updated_at',
 ];
 
-const SELECT_COLUMNS = SELECTABLE_FIELDS.map(field => {
-  const mapped = column(field);
-  return mapped === field ? mapped : `${mapped} AS ${field}`;
-}).join(',\n      ');
+function defaultTableState() {
+  return { name: 'recados', confirmed: false };
+}
 
-const INSERT_COLUMNS = INSERT_FIELDS.map(field => column(field)).join(',\n      ');
+function defaultColumnState() {
+  return { schema: 'modern', map: COLUMN_MAPS.modern, confirmed: false };
+}
 
-const INSERT_VALUES = INSERT_FIELDS.map(field => {
-  if (field === 'created_at' || field === 'updated_at') {
-    return `COALESCE(@${field}, datetime('now'))`;
+let tableState = defaultTableState();
+let columnState = defaultColumnState();
+let sqlCache = null;
+let legacyMigrationPending = true;
+
+function resetRuntime() {
+  tableState = defaultTableState();
+  columnState = defaultColumnState();
+  sqlCache = null;
+  legacyMigrationPending = true;
+}
+
+function ensureTable() {
+  if (!tableState.confirmed) {
+    const resolved = resolveMessageTable();
+    const tableChanged = tableState.name !== resolved.name;
+    tableState = resolved;
+    if (tableChanged) {
+      columnState = defaultColumnState();
+      sqlCache = null;
+    }
   }
-  return `@${field}`;
-}).join(',\n      ');
+  return tableState;
+}
 
-const STATUS_COLUMN = column('status');
-const ID_COLUMN = column('id');
-const RECIPIENT_COLUMN = column('recipient');
-const CALL_DATE_COLUMN = column('call_date');
-const CREATED_AT_COLUMN = column('created_at');
+function ensureColumnConfig() {
+  const { name: tableName } = ensureTable();
+  if (!columnState.confirmed) {
+    const resolved = resolveColumnMap(tableName);
+    const mapChanged = columnState.map !== resolved.map;
+    columnState = resolved;
+    if (mapChanged) {
+      sqlCache = null;
+    }
+  }
+  return columnState;
+}
+
+function buildSqlCache(map) {
+  const column = name => map[name] || name;
+  return {
+    map,
+    selectColumns: SELECTABLE_FIELDS.map(field => {
+      const mapped = column(field);
+      return mapped === field ? mapped : `${mapped} AS ${field}`;
+    }).join(',\n      '),
+    insertColumns: INSERT_FIELDS.map(column).join(',\n      '),
+    insertValues: INSERT_FIELDS.map(field => {
+      if (field === 'created_at' || field === 'updated_at') {
+        return `COALESCE(@${field}, datetime('now'))`;
+      }
+      return `@${field}`;
+    }).join(',\n      '),
+    statusColumn: column('status'),
+    idColumn: column('id'),
+    recipientColumn: column('recipient'),
+    callDateColumn: column('call_date'),
+    createdAtColumn: column('created_at'),
+  };
+}
+
+function getRuntime() {
+  const tableInfo = ensureTable();
+  const columnInfo = ensureColumnConfig();
+
+  if (!sqlCache || sqlCache.map !== columnInfo.map) {
+    sqlCache = buildSqlCache(columnInfo.map);
+  }
+
+  const column = name => columnInfo.map[name] || name;
+
+  return {
+    table: tableInfo.name,
+    schema: columnInfo.schema,
+    confirmed: tableInfo.confirmed && columnInfo.confirmed,
+    column,
+    selectColumns: sqlCache.selectColumns,
+    insertColumns: sqlCache.insertColumns,
+    insertValues: sqlCache.insertValues,
+    statusColumn: sqlCache.statusColumn,
+    idColumn: sqlCache.idColumn,
+    recipientColumn: sqlCache.recipientColumn,
+    callDateColumn: sqlCache.callDateColumn,
+    createdAtColumn: sqlCache.createdAtColumn,
+  };
+}
+
+function shouldRetryError(err) {
+  if (!err || typeof err.message !== 'string') return false;
+  return /no such table/i.test(err.message) || /no column/i.test(err.message);
+}
+
+function attemptLegacyMigration(runtime) {
+  if (!legacyMigrationPending || !runtime.confirmed) return;
+
+  try {
+    const database = db();
+    const exists = database
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=@table LIMIT 1")
+      .get({ table: runtime.table });
+
+    if (!exists) {
+      return;
+    }
+
+    const updates = [
+      { from: 'pendente', to: 'pending' },
+      { from: 'em_andamento', to: 'in_progress' },
+      { from: 'resolvido', to: 'resolved' },
+    ];
+
+    const updateStmt = database.prepare(`
+      UPDATE ${runtime.table}
+         SET ${runtime.statusColumn} = @to
+       WHERE ${runtime.statusColumn} = @from
+    `);
+
+    for (const pair of updates) {
+      updateStmt.run(pair);
+    }
+  } catch (err) {
+    console.warn('[message:model] Falha ao migrar status legados:', err.message);
+  } finally {
+    legacyMigrationPending = false;
+  }
+}
+
+function withRuntime(callback) {
+  let lastError;
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    if (attempt === 1) {
+      resetRuntime();
+    }
+
+    const runtime = getRuntime();
+    attemptLegacyMigration(runtime);
+
+    try {
+      return callback(runtime);
+    } catch (err) {
+      lastError = err;
+      if (attempt === 0 && shouldRetryError(err)) {
+        continue;
+      }
+      throw err;
+    }
+  }
+
+  throw lastError;
+}
 
 const STATUS_EN_TO_PT = {
   pending: 'pendente',
@@ -230,7 +368,7 @@ function normalizePayload(payload = {}) {
       callback_time: emptyToNull(payload.callback_time),
       notes: emptyToNull(payload.notes),
     },
-    statusProvided: statusProvided,
+    statusProvided,
   };
 }
 
@@ -253,33 +391,6 @@ function mapRow(row) {
     created_at: row.created_at ?? null,
     updated_at: row.updated_at ?? null,
   };
-}
-
-function migrateLegacyStatuses() {
-  const database = db();
-  try {
-    const statement = database.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name=@table LIMIT 1`);
-    const exists = statement.get({ table: TABLE });
-    if (!exists) return;
-
-    const updates = [
-      { from: 'pendente', to: 'pending' },
-      { from: 'em_andamento', to: 'in_progress' },
-      { from: 'resolvido', to: 'resolved' },
-    ];
-
-    const updateStmt = database.prepare(`
-      UPDATE ${TABLE}
-         SET ${STATUS_COLUMN} = @to
-       WHERE ${STATUS_COLUMN} = @from
-    `);
-
-    for (const pair of updates) {
-      updateStmt.run(pair);
-    }
-  } catch (err) {
-    console.warn('[message:model] Falha ao migrar status legados:', err.message);
-  }
 }
 
 function ensureStatus(value) {
@@ -305,133 +416,164 @@ function attachTimestamps(payload, source = {}) {
 }
 
 function selectBase(
+  runtime,
   whereClause = '',
-  orderClause = `ORDER BY ${ID_COLUMN} DESC`,
+  orderClause,
   limitClause = 'LIMIT @limit OFFSET @offset'
 ) {
+  const orderSegment = orderClause || `ORDER BY ${runtime.idColumn} DESC`;
   return `
     SELECT
-      ${SELECT_COLUMNS}
-      FROM ${TABLE}
+      ${runtime.selectColumns}
+      FROM ${runtime.table}
       ${whereClause}
-      ${orderClause}
+      ${orderSegment}
       ${limitClause}
   `;
 }
 
 function create(payload) {
-  const normalizedPayload = normalizePayload(payload);
-  const timestamps = attachTimestamps({}, payload);
-  const data = {
-    ...normalizedPayload.data,
-    status: normalizedPayload.statusProvided && normalizedPayload.data.status
-      ? normalizedPayload.data.status
-      : 'pending',
-  };
-  const info = db().prepare(`
-    INSERT INTO ${TABLE} (
-      ${INSERT_COLUMNS}
-    ) VALUES (
-      ${INSERT_VALUES}
-    )
-  `).run({ ...data, ...timestamps });
+  return withRuntime(runtime => {
+    const normalizedPayload = normalizePayload(payload);
+    const timestamps = attachTimestamps({}, payload);
+    const data = {
+      ...normalizedPayload.data,
+      status:
+        normalizedPayload.statusProvided && normalizedPayload.data.status
+          ? normalizedPayload.data.status
+          : 'pending',
+    };
 
-  return info.lastInsertRowid;
+    const info = db()
+      .prepare(`
+        INSERT INTO ${runtime.table} (
+          ${runtime.insertColumns}
+        ) VALUES (
+          ${runtime.insertValues}
+        )
+      `)
+      .run({ ...data, ...timestamps });
+
+    return info.lastInsertRowid;
+  });
 }
 
 function findById(id) {
-  const row = db().prepare(`
-    SELECT
-      ${SELECT_COLUMNS}
-      FROM ${TABLE}
-     WHERE ${ID_COLUMN} = @id
-     LIMIT 1
-  `).get({ id });
-  return mapRow(row);
+  return withRuntime(runtime => {
+    const row = db()
+      .prepare(`
+        SELECT
+          ${runtime.selectColumns}
+          FROM ${runtime.table}
+         WHERE ${runtime.idColumn} = @id
+         LIMIT 1
+      `)
+      .get({ id });
+    return mapRow(row);
+  });
 }
 
 function update(id, payload) {
-  const normalizedPayload = normalizePayload(payload);
-  const info = db().prepare(`
-    UPDATE ${TABLE}
-       SET ${column('call_date')}     = @call_date,
-           ${column('call_time')}     = @call_time,
-           ${column('recipient')}     = @recipient,
-           ${column('sender_name')}   = @sender_name,
-           ${column('sender_phone')}  = @sender_phone,
-           ${column('sender_email')}  = @sender_email,
-           ${column('subject')}       = @subject,
-           ${column('message')}       = @message,
-           ${STATUS_COLUMN}           = COALESCE(@status, ${STATUS_COLUMN}),
-           ${column('callback_time')} = @callback_time,
-           ${column('notes')}         = @notes,
-           ${column('updated_at')}    = datetime('now')
-     WHERE ${ID_COLUMN} = @id
-  `).run({ id, ...normalizedPayload.data, status: normalizedPayload.statusProvided ? normalizedPayload.data.status : null });
+  return withRuntime(runtime => {
+    const normalizedPayload = normalizePayload(payload);
+    const info = db()
+      .prepare(`
+        UPDATE ${runtime.table}
+           SET ${runtime.column('call_date')}     = @call_date,
+               ${runtime.column('call_time')}     = @call_time,
+               ${runtime.column('recipient')}     = @recipient,
+               ${runtime.column('sender_name')}   = @sender_name,
+               ${runtime.column('sender_phone')}  = @sender_phone,
+               ${runtime.column('sender_email')}  = @sender_email,
+               ${runtime.column('subject')}       = @subject,
+               ${runtime.column('message')}       = @message,
+               ${runtime.statusColumn}            = COALESCE(@status, ${runtime.statusColumn}),
+               ${runtime.column('callback_time')} = @callback_time,
+               ${runtime.column('notes')}         = @notes,
+               ${runtime.column('updated_at')}    = datetime('now')
+         WHERE ${runtime.idColumn} = @id
+      `)
+      .run({
+        id,
+        ...normalizedPayload.data,
+        status: normalizedPayload.statusProvided ? normalizedPayload.data.status : null,
+      });
 
-  return info.changes > 0;
+    return info.changes > 0;
+  });
 }
 
 function updateStatus(id, status) {
-  const normalized = ensureStatus(status);
-  const info = db().prepare(`
-    UPDATE ${TABLE}
-       SET ${STATUS_COLUMN}        = @status,
-           ${column('updated_at')} = datetime('now')
-     WHERE ${ID_COLUMN} = @id
-  `).run({ id, status: normalized });
-  return info.changes > 0;
+  return withRuntime(runtime => {
+    const normalized = ensureStatus(status);
+    const info = db()
+      .prepare(`
+        UPDATE ${runtime.table}
+           SET ${runtime.statusColumn}        = @status,
+               ${runtime.column('updated_at')} = datetime('now')
+         WHERE ${runtime.idColumn} = @id
+      `)
+      .run({ id, status: normalized });
+    return info.changes > 0;
+  });
 }
 
 function remove(id) {
-  const info = db().prepare(`DELETE FROM ${TABLE} WHERE ${ID_COLUMN} = @id`).run({ id });
-  return info.changes > 0;
+  return withRuntime(runtime => {
+    const info = db()
+      .prepare(`DELETE FROM ${runtime.table} WHERE ${runtime.idColumn} = @id`)
+      .run({ id });
+    return info.changes > 0;
+  });
 }
 
 function list({ limit = 10, offset = 0, status, start_date, end_date, recipient } = {}) {
-  const parsedLimit = Number(limit);
-  const parsedOffset = Number(offset);
-  const sanitizedLimit = Number.isFinite(parsedLimit) && parsedLimit > 0 ? Math.min(parsedLimit, 200) : 10;
-  const sanitizedOffset = Number.isFinite(parsedOffset) && parsedOffset >= 0 ? parsedOffset : 0;
-  const statusFilter = translateStatusForQuery(status);
+  return withRuntime(runtime => {
+    const parsedLimit = Number(limit);
+    const parsedOffset = Number(offset);
+    const sanitizedLimit = Number.isFinite(parsedLimit) && parsedLimit > 0 ? Math.min(parsedLimit, 200) : 10;
+    const sanitizedOffset = Number.isFinite(parsedOffset) && parsedOffset >= 0 ? parsedOffset : 0;
+    const statusFilter = translateStatusForQuery(status);
 
-  const startDate = trim(start_date);
-  const endDate = trim(end_date);
-  const recipientFilter = trim(recipient);
-  const effectiveDateColumn = `COALESCE(NULLIF(TRIM(${CALL_DATE_COLUMN}), ''), ${CREATED_AT_COLUMN})`;
+    const startDate = trim(start_date);
+    const endDate = trim(end_date);
+    const recipientFilter = trim(recipient);
+    const effectiveDateColumn = `COALESCE(NULLIF(TRIM(${runtime.callDateColumn}), ''), ${runtime.createdAtColumn})`;
 
-  const conditions = [];
-  const params = {
-    limit: sanitizedLimit,
-    offset: sanitizedOffset,
-  };
+    const conditions = [];
+    const params = {
+      limit: sanitizedLimit,
+      offset: sanitizedOffset,
+    };
 
-  if (statusFilter) {
-    conditions.push(`${STATUS_COLUMN} IN (@status, @legacy)`);
-    params.status = statusFilter.current;
-    params.legacy = statusFilter.legacy;
-  }
+    if (statusFilter) {
+      conditions.push(`${runtime.statusColumn} IN (@status, @legacy)`);
+      params.status = statusFilter.current;
+      params.legacy = statusFilter.legacy;
+    }
 
-  if (startDate) {
-    conditions.push(`DATE(${effectiveDateColumn}) >= DATE(@start_date)`);
-    params.start_date = startDate;
-  }
+    if (startDate) {
+      conditions.push(`DATE(${effectiveDateColumn}) >= DATE(@start_date)`);
+      params.start_date = startDate;
+    }
 
-  if (endDate) {
-    conditions.push(`DATE(${effectiveDateColumn}) <= DATE(@end_date)`);
-    params.end_date = endDate;
-  }
+    if (endDate) {
+      conditions.push(`DATE(${effectiveDateColumn}) <= DATE(@end_date)`);
+      params.end_date = endDate;
+    }
 
-  if (recipientFilter) {
-    conditions.push(`LOWER(COALESCE(TRIM(${RECIPIENT_COLUMN}), '')) LIKE @recipient`);
-    params.recipient = `%${recipientFilter.toLowerCase()}%`;
-  }
+    if (recipientFilter) {
+      conditions.push(`LOWER(COALESCE(TRIM(${runtime.recipientColumn}), '')) LIKE @recipient`);
+      params.recipient = `%${recipientFilter.toLowerCase()}%`;
+    }
 
-  const whereClause = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+    const whereClause = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
 
-  const query = selectBase(whereClause);
-  const rows = db().prepare(query).all(params);
-  return rows.map(mapRow);
+    const query = selectBase(runtime, whereClause);
+    const rows = db().prepare(query).all(params);
+
+    return rows.map(mapRow);
+  });
 }
 
 function listRecent(limit = 10) {
@@ -439,26 +581,30 @@ function listRecent(limit = 10) {
 }
 
 function stats() {
-  const database = db();
-  const total = database.prepare(`SELECT COUNT(*) AS count FROM ${TABLE}`).get().count;
+  return withRuntime(runtime => {
+    const database = db();
+    const total = database.prepare(`SELECT COUNT(*) AS count FROM ${runtime.table}`).get().count;
 
-  const counters = {};
-  for (const status of STATUS_VALUES) {
-    const legacy = STATUS_EN_TO_PT[status];
-    const row = database.prepare(`
-      SELECT COUNT(*) AS count
-        FROM ${TABLE}
-       WHERE ${STATUS_COLUMN} IN (@status, @legacy)
-    `).get({ status, legacy });
-    counters[status] = row.count;
-  }
+    const counters = {};
+    for (const status of STATUS_VALUES) {
+      const legacy = STATUS_EN_TO_PT[status];
+      const row = database
+        .prepare(`
+          SELECT COUNT(*) AS count
+            FROM ${runtime.table}
+           WHERE ${runtime.statusColumn} IN (@status, @legacy)
+        `)
+        .get({ status, legacy });
+      counters[status] = row.count;
+    }
 
-  return {
-    total,
-    pending: counters.pending || 0,
-    in_progress: counters.in_progress || 0,
-    resolved: counters.resolved || 0,
-  };
+    return {
+      total,
+      pending: counters.pending || 0,
+      in_progress: counters.in_progress || 0,
+      resolved: counters.resolved || 0,
+    };
+  });
 }
 
 function sanitizeLimit(limit, { fallback = 10, max = 100 } = {}) {
@@ -470,68 +616,88 @@ function sanitizeLimit(limit, { fallback = 10, max = 100 } = {}) {
 }
 
 function statsByRecipient({ limit = 10 } = {}) {
-  const sanitizedLimit = sanitizeLimit(limit, { fallback: 10, max: 100 });
-  const rows = db().prepare(`
-    SELECT
-      COALESCE(NULLIF(TRIM(${RECIPIENT_COLUMN}), ''), 'Não informado') AS recipient,
-      COUNT(*) AS count
-      FROM ${TABLE}
-  GROUP BY recipient
-  ORDER BY count DESC, recipient ASC
-     LIMIT @limit
-  `).all({ limit: sanitizedLimit });
+  return withRuntime(runtime => {
+    const sanitizedLimit = sanitizeLimit(limit, { fallback: 10, max: 100 });
+    const rows = db()
+      .prepare(`
+        SELECT
+          COALESCE(NULLIF(TRIM(${runtime.recipientColumn}), ''), 'Não informado') AS recipient,
+          COUNT(*) AS count
+          FROM ${runtime.table}
+      GROUP BY recipient
+      ORDER BY count DESC, recipient ASC
+         LIMIT @limit
+      `)
+      .all({ limit: sanitizedLimit });
 
-  return rows.map(row => ({ recipient: row.recipient, count: row.count }));
+    return rows.map(row => ({ recipient: row.recipient, count: row.count }));
+  });
 }
 
 function statsByStatus() {
-  const totals = STATUS_VALUES.reduce((acc, status) => {
-    acc[status] = 0;
-    return acc;
-  }, {});
+  return withRuntime(runtime => {
+    const totals = STATUS_VALUES.reduce((acc, status) => {
+      acc[status] = 0;
+      return acc;
+    }, {});
 
-  const rows = db().prepare(`
-    SELECT
-      ${STATUS_COLUMN} AS raw_status,
-      COUNT(*)         AS count
-      FROM ${TABLE}
-  GROUP BY ${STATUS_COLUMN}
-  `).all();
+    const rows = db()
+      .prepare(`
+        SELECT
+          ${runtime.statusColumn} AS raw_status,
+          COUNT(*)         AS count
+          FROM ${runtime.table}
+      GROUP BY ${runtime.statusColumn}
+      `)
+      .all();
 
-  for (const row of rows) {
-    const normalized = normalizeStatus(row.raw_status);
-    totals[normalized] = (totals[normalized] || 0) + (row.count || 0);
-  }
+    for (const row of rows) {
+      const normalized = normalizeStatus(row.raw_status);
+      totals[normalized] = (totals[normalized] || 0) + (row.count || 0);
+    }
 
-  return STATUS_VALUES.map(status => ({
-    status,
-    label: STATUS_LABELS_PT[status] || status,
-    count: totals[status] || 0,
-  }));
+    return STATUS_VALUES.map(status => ({
+      status,
+      label: STATUS_LABELS_PT[status] || status,
+      count: totals[status] || 0,
+    }));
+  });
 }
 
 function statsByMonth({ limit = 12 } = {}) {
-  const sanitizedLimit = sanitizeLimit(limit, { fallback: 12, max: 120 });
-  const rows = db().prepare(`
-    WITH aggregated AS (
-      SELECT
-        strftime('%Y-%m', CASE
-          WHEN ${CALL_DATE_COLUMN} IS NOT NULL AND TRIM(${CALL_DATE_COLUMN}) != ''
-            THEN ${CALL_DATE_COLUMN}
-          ELSE ${CREATED_AT_COLUMN}
-        END) AS month,
-        COUNT(*) AS count
-        FROM ${TABLE}
-    GROUP BY month
-      HAVING month IS NOT NULL
-    )
-    SELECT month, count
-      FROM aggregated
-  ORDER BY month DESC
-     LIMIT @limit
-  `).all({ limit: sanitizedLimit });
+  return withRuntime(runtime => {
+    const sanitizedLimit = sanitizeLimit(limit, { fallback: 12, max: 120 });
+    const rows = db()
+      .prepare(`
+        WITH aggregated AS (
+          SELECT
+            strftime('%Y-%m', CASE
+              WHEN ${runtime.callDateColumn} IS NOT NULL AND TRIM(${runtime.callDateColumn}) != ''
+                THEN ${runtime.callDateColumn}
+              ELSE ${runtime.createdAtColumn}
+            END) AS month,
+            COUNT(*) AS count
+            FROM ${runtime.table}
+        GROUP BY month
+          HAVING month IS NOT NULL
+        )
+        SELECT month, count
+          FROM aggregated
+      ORDER BY month DESC
+         LIMIT @limit
+      `)
+      .all({ limit: sanitizedLimit });
 
-  return rows.reverse().map(row => ({ month: row.month, count: row.count }));
+    return rows.reverse().map(row => ({ month: row.month, count: row.count }));
+  });
+}
+
+function migrateLegacyStatuses() {
+  try {
+    withRuntime(() => {});
+  } catch (err) {
+    console.warn('[message:model] Falha ao executar migração inicial de status:', err.message);
+  }
 }
 
 migrateLegacyStatuses();


### PR DESCRIPTION
## Summary
- add runtime helpers that dynamically resolve the messages table and schema mappings with retry and caching
- update CRUD, list, and statistics queries to use runtime-aware column resolution and apply legacy status migrations automatically
- expose shared utilities for normalization and stats while warming up the runtime to keep legacy databases compatible

## Testing
- npm test -- --runTestsByPath __tests__/recado.legacy-timestamps.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d3f0a03628832491832d9c6ed1a077