### PR TITLE
Implement manual CORS handling middleware

### DIFF
--- a/server.js
+++ b/server.js
@@ -52,7 +52,11 @@ app.set('views', path.join(__dirname, 'views'));
 // ─── CORS / Pré-flight ───────────────────────────────────────────────────────
 app.use(corsMw);
 // Express 5 + path-to-regexp v7: use regex para OPTIONS global
-app.options(/.*/, corsMw);
+app.options(/.*/, corsMw, (req, res) => {
+  res.setHeader('Access-Control-Allow-Methods', corsMw.ALLOWED_METHODS);
+  res.setHeader('Access-Control-Allow-Headers', corsMw.ALLOWED_HEADERS);
+  res.sendStatus(204);
+});
 
 // Validação de origem (se fornecida) apenas em produção
 if (isProd && validateOrigin) app.use(validateOrigin);


### PR DESCRIPTION
## Summary
- replace the CORS package with a manual middleware that builds the origin whitelist from `CORS_ORIGINS` while always permitting the production domains
- set CORS response headers for approved origins, log warnings for rejected origins, and reuse the middleware for OPTIONS requests
- expose allowed method/header values so the global `OPTIONS` handler can share them when replying with 204

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7525a38c08324b6c6fdb1e11429b1