### PR TITLE
Handle login renders without CSRF middleware

### DIFF
--- a/__tests__/auth.login.test.js
+++ b/__tests__/auth.login.test.js
@@ -1,0 +1,54 @@
+const express = require('express');
+const { body } = require('express-validator');
+const supertest = require('supertest');
+
+const authController = require('../controllers/authController');
+
+describe('POST /login without CSRF middleware', () => {
+  function createApp() {
+    const app = express();
+    app.use(express.urlencoded({ extended: false }));
+    app.use(express.json());
+
+    // Simula sessão mínima utilizada pelo controller
+    app.use((req, _res, next) => {
+      req.session = req.session || {};
+      next();
+    });
+
+    // Stub de renderização que devolve JSON com os dados usados na view
+    app.use((req, res, next) => {
+      res.render = (view, locals = {}) => {
+        res.type('application/json');
+        return res.send({ view, locals });
+      };
+      next();
+    });
+
+    app.post(
+      '/login',
+      body('email').isEmail(),
+      body('password').notEmpty(),
+      authController.login
+    );
+
+    return app;
+  }
+
+  it('retorna 400 renderizando a view de login mesmo sem token CSRF', async () => {
+    const app = createApp();
+
+    const response = await supertest(app)
+      .post('/login')
+      .set('Accept', 'text/html')
+      .type('form')
+      .send({ email: 'usuario-sem-token', password: '' });
+
+    expect(response.status).toBe(400);
+    expect(response.body.view).toBe('login');
+    expect(response.body.locals.title).toBe('Login');
+    expect(response.body.locals.csrfToken).toBeUndefined();
+    expect(Array.isArray(response.body.locals.errors)).toBe(true);
+    expect(response.body.locals.errors.length).toBeGreaterThan(0);
+  });
+});

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -36,15 +36,16 @@ exports.showLogin = (req, res) => {
 exports.login = async (req, res) => {
   const errors = validationResult(req);
   const wants = wantsJson(req);
+  const csrfToken = typeof req.csrfToken === 'function' ? req.csrfToken() : undefined;
+  const buildViewData = extra => (csrfToken !== undefined ? { ...extra, csrfToken } : extra);
   if (!errors.isEmpty()) {
     if (wants) {
       return res.status(400).json({ success: false, error: 'Dados inválidos' });
     }
-    return res.status(400).render('login', {
+    return res.status(400).render('login', buildViewData({
       title: 'Login',
-      csrfToken: req.csrfToken(),
       errors: errors.array(),
-    });
+    }));
   }
 
   const email = String(req.body.email || '').trim().toLowerCase();
@@ -60,11 +61,10 @@ exports.login = async (req, res) => {
       if (wants) {
         return res.status(401).json({ success: false, error: 'Credenciais inválidas' });
       }
-      return res.status(401).render('login', {
+      return res.status(401).render('login', buildViewData({
         title: 'Login',
-        csrfToken: req.csrfToken(),
         error: 'Credenciais inválidas',
-      });
+      }));
     }
 
     const hash = user.password_hash;
@@ -73,11 +73,10 @@ exports.login = async (req, res) => {
       if (wants) {
         return res.status(401).json({ success: false, error: 'Credenciais inválidas' });
       }
-      return res.status(401).render('login', {
+      return res.status(401).render('login', buildViewData({
         title: 'Login',
-        csrfToken: req.csrfToken(),
         error: 'Credenciais inválidas',
-      });
+      }));
     }
 
     const ok = await argon2.verify(hash, password);
@@ -85,11 +84,10 @@ exports.login = async (req, res) => {
       if (wants) {
         return res.status(401).json({ success: false, error: 'Credenciais inválidas' });
       }
-      return res.status(401).render('login', {
+      return res.status(401).render('login', buildViewData({
         title: 'Login',
-        csrfToken: req.csrfToken(),
         error: 'Credenciais inválidas',
-      });
+      }));
     }
 
     const sessionUser = {
@@ -123,11 +121,10 @@ exports.login = async (req, res) => {
     if (wants) {
       return res.status(500).json({ success: false, error: 'Erro interno' });
     }
-    return res.status(500).render('login', {
+    return res.status(500).render('login', buildViewData({
       title: 'Login',
-      csrfToken: req.csrfToken(),
       error: 'Erro interno',
-    });
+    }));
   }
 };
 


### PR DESCRIPTION
## Summary
- guard the login controller against missing csrf middleware by reading the token safely and reusing it across renders
- update login renders to only include the csrf token when available and add a regression test for HTML failures without csrf

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db362f0554832498e9b72849cb215b