### PR TITLE
Padroniza payload de erros de validação

### DIFF
--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -41,7 +41,11 @@ exports.create = async (req, res) => {
   const role     = String(req.body.role || 'OPERADOR').trim().toUpperCase();
 
   if (!errors.isEmpty()) {
-    return res.status(400).json({ success: false, errors: errors.array() });
+    return res.status(400).json({
+      success: false,
+      error: 'Dados inválidos',
+      details: errors.array(),
+    });
   }
 
   try {

--- a/middleware/validation.js
+++ b/middleware/validation.js
@@ -195,8 +195,8 @@ function handleValidationErrors(req, res, next) {
   if (result.isEmpty()) return next();
   return res.status(400).json({
     success: false,
-    message: 'Dados inválidos',
-    errors: result.array()
+    error: 'Dados inválidos',
+    details: result.array(),
   });
 }
 

--- a/public/js/editar-recado.js
+++ b/public/js/editar-recado.js
@@ -59,7 +59,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       Toast.success('Recado atualizado com sucesso!');
       setTimeout(() => (window.location.href = `/visualizar-recado/${id}`), 1000);
     } catch (err) {
-      const validationError = err.body?.errors?.[0] || err.errors?.[0];
+      const validationError = err.body?.details?.[0] || err.details?.[0] || err.body?.errors?.[0] || err.errors?.[0];
       const msg = validationError?.msg || validationError?.message || err.message || 'Erro ao atualizar recado';
       Toast.error(msg);
     } finally {


### PR DESCRIPTION
## Summary
- padroniza o retorno de erros de validação na criação de usuários e middleware
- ajusta o front-end para consumir o novo campo details ao exibir validações

## Testing
- npm test -- --runTestsByPath __tests__/auth.login.test.js __tests__/recado.legacy-timestamps.test.js

------
https://chatgpt.com/codex/tasks/task_e_68db3e1d32708324889d12e7e47d7d35