### PR TITLE
Ajusta rota de CSRF para login

### DIFF
--- a/public/js/login.js
+++ b/public/js/login.js
@@ -11,7 +11,7 @@
 
     async function loadCsrfToken() {
       try {
-        const response = await fetch('/api/csrf-token', {
+        const response = await fetch('/api/csrf', {
           method: 'GET',
           headers: { Accept: 'application/json' },
           credentials: 'include'

--- a/routes/api.js
+++ b/routes/api.js
@@ -82,7 +82,7 @@ router.patch('/users/:id/active', userController.setActive);
 // ---------------------------------------------------------------------------
 router.get('/healthz', (_req, res) => res.json({ success: true, data: { ok: true } }));
 
-router.get('/csrf-token', csrfProtection, (req, res) => {
+router.get('/csrf', csrfProtection, (req, res) => {
   const token = req.csrfToken();
   res.json({ success: true, data: { token } });
 });


### PR DESCRIPTION
## Resumo
- altera a rota da API para expor o token CSRF em `/api/csrf`
- atualiza o script de login para consumir a nova rota ao buscar o token

## Testes
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db43730e348324ab6ae05f6e4a421b