### PR TITLE
Add admin seeding script and document usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,11 @@ git clone <repo>
 cd late
 npm install
 node scripts/migrate.js # aplica migrations de data/migrations
+# (Opcional, mas recomendado) defina variáveis para o usuário administrador inicial
+# export ADMIN_NAME="Administrador"
+# export ADMIN_EMAIL="admin@example.com"
+# export ADMIN_PASSWORD="altere-esta-senha"
+node scripts/seed-admin.js # cria o usuário administrador padrão (evita duplicados)
 # Defina os domínios permitidos no CORS via CORS_ORIGINS
 # (ALLOWED_ORIGINS ainda é suportada, mas será descontinuada futuramente)
 # Separe por vírgula **ou** espaço. Quando não definido, utiliza os domínios padrão

--- a/scripts/seed-admin.js
+++ b/scripts/seed-admin.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+
+require('dotenv').config();
+
+const argon2 = require('argon2');
+const UserModel = require('../models/user');
+const database = require('../config/database');
+
+async function main() {
+  const name = (process.env.ADMIN_NAME || 'Administrador').trim();
+  const email = (process.env.ADMIN_EMAIL || 'admin@example.com').trim().toLowerCase();
+  const password = process.env.ADMIN_PASSWORD || 'trocar-senha';
+
+  if (!email) {
+    console.error('[seed-admin] É necessário definir ADMIN_EMAIL (ou ajustar no script).');
+    process.exit(1);
+  }
+
+  if (!password) {
+    console.error('[seed-admin] É necessário definir ADMIN_PASSWORD (ou ajustar no script).');
+    process.exit(1);
+  }
+
+  try {
+    const existing = await UserModel.findByEmail(email);
+    if (existing) {
+      console.info(`[seed-admin] Usuário administrador já existe: ${email}`);
+      return;
+    }
+
+    const password_hash = await argon2.hash(password, { type: argon2.argon2id });
+    await UserModel.create({ name, email, password_hash, role: 'ADMIN' });
+    console.info(`[seed-admin] Usuário administrador criado: ${email}`);
+  } catch (err) {
+    console.error('[seed-admin] Falha ao criar usuário administrador:', err.message);
+    process.exitCode = 1;
+  } finally {
+    await database.close();
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add a seed-admin utility that hashes credentials with argon2 and creates the default ADMIN account only when absent
- document the post-migration seeding step and related environment variables in the README for new deployments

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ddca94394c8324abb5ce4a31d1a023