### PR TITLE
Fix/stats endpoints

### DIFF
--- a/controllers/messageController.js
+++ b/controllers/messageController.js
@@ -1,20 +1,29 @@
+// controllers/messageController.js
+// Comentários em pt-BR; identificadores em inglês.
+
 const MessageModel = require('../models/message');
 
+// Converte snake_case → camelCase para datas, preservando os campos originais.
 function formatMessage(message) {
   if (!message) return null;
   return {
     ...message,
-    status_label: MessageModel.STATUS_LABELS_PT[message.status] || message.status,
+    status_label: MessageModel.STATUS_LABELS_PT?.[message.status] || message.status,
+    createdAt: message.created_at ? new Date(message.created_at).toISOString() : null,
+    updatedAt: message.updated_at ? new Date(message.updated_at).toISOString() : null,
   };
 }
 
+// Utilitário para montar payload de gráficos (labels/data) com fallback seguro.
 function toChartPayload(rows, { labelKey, valueKey, fallbackLabel = 'Não informado', transformLabel } = {}) {
   const labels = [];
   const data = [];
 
   for (const row of rows || []) {
     const rawLabel = labelKey ? row[labelKey] : row;
-    const baseLabel = rawLabel === undefined || rawLabel === null || rawLabel === '' ? fallbackLabel : rawLabel;
+    const baseLabel = (rawLabel === undefined || rawLabel === null || rawLabel === '')
+      ? fallbackLabel
+      : rawLabel;
     const finalLabel = transformLabel ? transformLabel(baseLabel, row) : baseLabel;
 
     const rawValue = valueKey ? row[valueKey] : row;
@@ -29,33 +38,68 @@ function toChartPayload(rows, { labelKey, valueKey, fallbackLabel = 'Não inform
 }
 
 function formatMonthLabel(label) {
-  if (!label || typeof label !== 'string') {
-    return 'Não informado';
-  }
-
-  const [year, month] = label.split('-');
-  if (year && month) {
+  if (!label || typeof label !== 'string') return 'Não informado';
+  const parts = label.split('-'); // 'YYYY-MM'
+  if (parts.length === 2) {
+    const [year, month] = parts;
     return `${month}/${year}`;
   }
-
   return label;
 }
 
+// ---------------------------------------------------------------------------
+// Listagem
+// Retorna também `items[]` e `meta` para compatibilidade com o front.
+// ---------------------------------------------------------------------------
 exports.list = async (req, res) => {
   try {
-    const { limit, offset, status, start_date, end_date, recipient } = req.query || {};
-    const messages = (await MessageModel.list({ limit, offset, status, start_date, end_date, recipient })).map(formatMessage);
-    return res.json({ success: true, data: messages });
+    const q = req.query || {};
+
+    // Defaults defensivos
+    const limit = Math.min(Math.max(parseInt(q.limit, 10) || 10, 1), 50);
+    const offset = Math.max(parseInt(q.offset, 10) || 0, 0);
+
+    const filters = {
+      status: q.status || null,
+      recipient: q.recipient || null,
+      q: q.q || null,
+      start_date: q.start_date || null,
+      end_date: q.end_date || null,
+      order_by: q.order_by || 'created_at',
+      order: (q.order || 'desc').toLowerCase() === 'asc' ? 'asc' : 'desc',
+      limit,
+      offset,
+    };
+
+    // O model pode retornar array puro ou { items, total }
+    const rowsOrObj = await MessageModel.list(filters);
+    const rawItems = Array.isArray(rowsOrObj) ? rowsOrObj : (rowsOrObj.items || []);
+    const total = Array.isArray(rowsOrObj) ? rawItems.length : (rowsOrObj.total ?? rawItems.length);
+
+    const items = rawItems.map(formatMessage);
+
+    return res.json({
+      success: true,
+      data: items,             // legado (alguns pontos do front ainda leem 'data' diretamente)
+      items,                   // formato novo e explícito
+      meta: { total, limit, offset }
+    });
   } catch (err) {
-    console.error('[messages] erro ao listar:', err);
-    return res.status(500).json({ success: false, error: 'Erro ao listar mensagens.' });
+    console.error('[messages] list error:', err);
+    return res.status(500).json({ success: false, error: 'Falha ao listar recados' });
   }
 };
 
+// ---------------------------------------------------------------------------
+// Obter por ID
+// ---------------------------------------------------------------------------
 exports.getById = async (req, res) => {
   try {
     const id = Number(req.params.id);
-    const message = await MessageModel.findById(id);
+    if (!id) return res.status(400).json({ success: false, error: 'ID inválido' });
+
+    // Alguns repos têm findById; outros getById — mantemos findById que já era usado aqui
+    const message = await MessageModel.findById ? MessageModel.findById(id) : MessageModel.getById(id);
     if (!message) {
       return res.status(404).json({ success: false, error: 'Mensagem não encontrada.' });
     }
@@ -66,10 +110,15 @@ exports.getById = async (req, res) => {
   }
 };
 
+// ---------------------------------------------------------------------------
+// Criar
+// ---------------------------------------------------------------------------
 exports.create = async (req, res) => {
   try {
     const id = await MessageModel.create(req.body || {});
-    const message = id ? await MessageModel.findById(id) : null;
+    const message = id
+      ? (MessageModel.findById ? await MessageModel.findById(id) : await MessageModel.getById(id))
+      : null;
     const formatted = message ? formatMessage(message) : { id };
     return res.status(201).json({ success: true, data: formatted });
   } catch (err) {
@@ -78,14 +127,17 @@ exports.create = async (req, res) => {
   }
 };
 
+// ---------------------------------------------------------------------------
+// Atualizar
+// ---------------------------------------------------------------------------
 exports.update = async (req, res) => {
   try {
     const id = Number(req.params.id);
-    const updated = await MessageModel.update(id, req.body || {});
-    if (!updated) {
+    const ok = await MessageModel.update(id, req.body || {});
+    if (!ok) {
       return res.status(404).json({ success: false, error: 'Mensagem não encontrada para atualização.' });
     }
-    const message = await MessageModel.findById(id);
+    const message = MessageModel.findById ? await MessageModel.findById(id) : await MessageModel.getById(id);
     return res.json({ success: true, data: formatMessage(message) });
   } catch (err) {
     console.error('[messages] erro ao atualizar mensagem:', err);
@@ -93,15 +145,18 @@ exports.update = async (req, res) => {
   }
 };
 
+// ---------------------------------------------------------------------------
+// Atualizar status
+// ---------------------------------------------------------------------------
 exports.updateStatus = async (req, res) => {
   try {
     const id = Number(req.params.id);
-    const status = req.body?.status;
-    const updated = await MessageModel.updateStatus(id, status);
-    if (!updated) {
+    const status = req.body && req.body.status;
+    const ok = await MessageModel.updateStatus(id, status);
+    if (!ok) {
       return res.status(404).json({ success: false, error: 'Mensagem não encontrada para atualização de status.' });
     }
-    const message = await MessageModel.findById(id);
+    const message = MessageModel.findById ? await MessageModel.findById(id) : await MessageModel.getById(id);
     return res.json({ success: true, data: formatMessage(message) });
   } catch (err) {
     console.error('[messages] erro ao atualizar status:', err);
@@ -109,11 +164,14 @@ exports.updateStatus = async (req, res) => {
   }
 };
 
+// ---------------------------------------------------------------------------
+// Remover
+// ---------------------------------------------------------------------------
 exports.remove = async (req, res) => {
   try {
     const id = Number(req.params.id);
-    const removed = await MessageModel.remove(id);
-    if (!removed) {
+    const ok = await MessageModel.remove(id);
+    if (!ok) {
       return res.status(404).json({ success: false, error: 'Mensagem não encontrada para exclusão.' });
     }
     return res.json({ success: true, data: { id, deleted: true } });
@@ -123,6 +181,9 @@ exports.remove = async (req, res) => {
   }
 };
 
+// ---------------------------------------------------------------------------
+// Estatísticas (cards/dashboard)
+// ---------------------------------------------------------------------------
 exports.stats = async (_req, res) => {
   try {
     const stats = await MessageModel.stats();
@@ -130,8 +191,12 @@ exports.stats = async (_req, res) => {
       success: true,
       data: {
         ...stats,
-        labels: MessageModel.STATUS_LABELS_PT,
-      },
+        labels: MessageModel.STATUS_LABELS_PT || {
+          pending: 'Pendente',
+          in_progress: 'Em andamento',
+          resolved: 'Resolvido'
+        }
+      }
     });
   } catch (err) {
     console.error('[messages] erro nas estatísticas:', err);
@@ -139,6 +204,9 @@ exports.stats = async (_req, res) => {
   }
 };
 
+// ---------------------------------------------------------------------------
+// Estatísticas por destinatário
+// ---------------------------------------------------------------------------
 exports.statsByRecipient = async (req, res) => {
   try {
     const { limit } = req.query || {};
@@ -146,50 +214,50 @@ exports.statsByRecipient = async (req, res) => {
     const payload = toChartPayload(rows, {
       labelKey: 'recipient',
       valueKey: 'count',
-      fallbackLabel: 'Não informado',
+      fallbackLabel: 'Não informado'
     });
-
     return res.json({ success: true, data: payload });
   } catch (err) {
     console.error('[messages] erro ao obter estatísticas por destinatário:', err);
-    return res
-      .status(500)
-      .json({ success: false, error: 'Erro ao obter estatísticas por destinatário.' });
+    return res.status(500).json({ success: false, error: 'Erro ao obter estatísticas por destinatário.' });
   }
 };
 
+// ---------------------------------------------------------------------------
+// Estatísticas por status
+// ---------------------------------------------------------------------------
 exports.statsByStatus = async (_req, res) => {
   try {
     const rows = await MessageModel.statsByStatus();
     const payload = toChartPayload(rows, {
       labelKey: 'label',
       valueKey: 'count',
-      fallbackLabel: 'Status desconhecido',
+      fallbackLabel: 'Status desconhecido'
     });
-
     return res.json({ success: true, data: payload });
   } catch (err) {
     console.error('[messages] erro ao obter estatísticas por status:', err);
-    return res
-      .status(500)
-      .json({ success: false, error: 'Erro ao obter estatísticas por status.' });
+    return res.status(500).json({ success: false, error: 'Erro ao obter estatísticas por status.' });
   }
 };
 
+// ---------------------------------------------------------------------------
+// Estatísticas por mês
+// ---------------------------------------------------------------------------
 exports.statsByMonth = async (req, res) => {
   try {
     const { limit } = req.query || {};
-    const rows = await MessageModel.statsByMonth({ limit });
+    const rows = await MessageModel.statsByMonth({ limit }); // ok se o model ignorar params
     const payload = toChartPayload(rows, {
       labelKey: 'month',
       valueKey: 'count',
       fallbackLabel: 'Não informado',
-      transformLabel: formatMonthLabel,
+      transformLabel: formatMonthLabel
     });
-
     return res.json({ success: true, data: payload });
   } catch (err) {
     console.error('[messages] erro ao obter estatísticas por mês:', err);
     return res.status(500).json({ success: false, error: 'Erro ao obter estatísticas por mês.' });
   }
 };
+

--- a/controllers/statsController.js
+++ b/controllers/statsController.js
@@ -1,0 +1,102 @@
+// controllers/statsController.js
+// Comentários em pt-BR; identificadores em inglês.
+// Controller somente para estatísticas (dashboard/relatórios).
+
+const StatsModel = require('../models/stats');
+
+// Normaliza intervalo de datas recebido por query (aceita start_date/end_date ou data_inicio/data_fim)
+function normalizeRange(q = {}) {
+  const start = String(q.start_date || q.data_inicio || '').trim();
+  const end   = String(q.end_date   || q.data_fim    || '').trim();
+  // Sem datas = intervalo amplo (evita 400/500 no dashboard/relatórios)
+  const startAt = start ? `${start} 00:00:00`    : '1970-01-01 00:00:00';
+  const endAt   = end   ? `${end} 23:59:59.999`  : '2100-01-01 00:00:00';
+  return { startAt, endAt };
+}
+
+// GET /api/messages/stats
+// Retorna no padrão esperado pelo front: { total, pending, in_progress, resolved, labels }
+exports.messagesStats = async (req, res) => {
+  try {
+    const { startAt, endAt } = normalizeRange(req.query);
+    const raw = await StatsModel.getMessagesStats({ startAt, endAt }); // { total, pendente, em_andamento, resolvido }
+
+    const data = {
+      total: Number(raw.total || 0),
+      pending: Number(raw.pendente || 0),
+      in_progress: Number(raw.em_andamento || 0),
+      resolved: Number(raw.resolvido || 0),
+      labels: {
+        pending: 'Pendente',
+        in_progress: 'Em andamento',
+        resolved: 'Resolvido',
+      }
+    };
+    return res.json({ success: true, data });
+  } catch (err) {
+    console.error('[messages/stats] erro:', err);
+    return res.status(400).json({ success: false, error: 'Dados inválidos' });
+  }
+};
+
+// GET /api/stats/by-status  -> { labels: [...], data: [...] }
+exports.byStatus = async (_req, res) => {
+  try {
+    // rows: [{ status, total }]
+    const rows = await StatsModel.getStatsByStatus();
+    // Ordem fixa para o gráfico
+    const order = ['pending', 'in_progress', 'resolved'];
+    const mapLabel = (s) => ({
+      pending: 'Pendente',
+      in_progress: 'Em andamento',
+      resolved: 'Resolvido'
+    }[s] || s);
+
+    const totalsByStatus = new Map(rows.map(r => [r.status, Number(r.total || 0)]));
+    const labels = order.map(mapLabel);
+    const data   = order.map(k => totalsByStatus.get(k) || 0);
+
+    return res.json({ success: true, data: { labels, data } });
+  } catch (err) {
+    console.error('[stats/by-status] erro:', err);
+    return res.status(500).json({ success: false, error: 'Erro ao obter estatísticas por status.' });
+  }
+};
+
+// GET /api/stats/by-recipient -> { labels: [...], data: [...] }
+exports.byRecipient = async (_req, res) => {
+  try {
+    // rows: [{ recipient, total }]; model usa 'Sem destinatário' para NULL
+    const rows = await StatsModel.getStatsByRecipient();
+    const labels = rows.map(r => (r.recipient === 'Sem destinatário' ? 'Não informado' : r.recipient));
+    const data   = rows.map(r => Number(r.total || 0));
+    return res.json({ success: true, data: { labels, data } });
+  } catch (err) {
+    console.error('[stats/by-recipient] erro:', err);
+    return res.status(500).json({ success: false, error: 'Erro ao obter estatísticas por destinatário.' });
+  }
+};
+
+// GET /api/stats/by-month -> { labels: ["MM/YYYY", ...], data: [N, ...] }
+exports.byMonth = async (_req, res) => {
+  try {
+    // rows: [{ month: 'YYYY-MM', total: int }]
+    const rows = await StatsModel.getStatsByMonth({ months: 12 });
+
+    // Formato que o front espera: MM/YYYY
+    const toMMYYYY = (yyyyMM) => {
+      // yyyyMM no formato 'YYYY-MM'
+      const [y, m] = String(yyyyMM).split('-');
+      if (!y || !m) return yyyyMM;
+      return `${m}/${y}`;
+    };
+
+    const labels = rows.map(r => toMMYYYY(r.month));
+    const data   = rows.map(r => Number(r.total || 0));
+    return res.json({ success: true, data: { labels, data } });
+  } catch (err) {
+    console.error('[stats/by-month] erro:', err);
+    return res.status(500).json({ success: false, error: 'Erro ao obter estatísticas por mês.' });
+  }
+};
+

--- a/middleware/validation.js
+++ b/middleware/validation.js
@@ -1,182 +1,240 @@
-'use strict';
+// middleware/validation.js
+// Comentários em pt-BR; identificadores em inglês.
+// Regras de validação/sanitização centralizadas (express-validator).
 
-// middleware/validation.js — versão compatível (sem optional chaining / nullish coalescing)
-// - Normaliza campos do corpo e da query (status, e-mails vazios -> null, strings vazias -> null)
-// - Validações usando express-validator (apenas APIs estáveis)
-
-var expressValidator = require('express-validator');
+const expressValidator = require('express-validator');
 var body   = expressValidator.body;
 var param  = expressValidator.param;
 var query  = expressValidator.query;
 var validationResult = expressValidator.validationResult;
 
-var MessageModel = require('../models/message');
+// -------------------------------------------------------------
+// Helpers comuns
+// -------------------------------------------------------------
 
-// ---------------------------------------------------------------------------
-// Helpers de normalização
-// ---------------------------------------------------------------------------
-var ALLOWED_STATUS = MessageModel.STATUS_VALUES;
+// Status permitidos no back-end
+var ALLOWED_STATUS = ['pending', 'in_progress', 'resolved'];
 
-function toStr(v) { return (v === undefined || v === null) ? '' : String(v); }
-function isBlank(v) { return toStr(v).trim() === ''; }
-function emptyToNull(v) { return isBlank(v) ? null : v; }
-
-function normalizeStatus(raw) {
-  var value = toStr(raw).trim();
-  if (!value) return '';
-  return MessageModel.normalizeStatus(value);
+/**
+ * Normaliza valores de status vindos do usuário.
+ * Suporta apelidos em pt-BR para conveniência.
+ */
+function normalizeStatus(s) {
+  if (!s) return '';
+  var v = String(s).trim().toLowerCase();
+  // variações em pt-BR
+  if (v === 'pendente' || v === 'pendentes') return 'pending';
+  if (v === 'em andamento' || v === 'andamento' || v === 'em_andamento') return 'in_progress';
+  if (v === 'resolvido' || v === 'resolvidos') return 'resolved';
+  // inglês já padronizado
+  if (ALLOWED_STATUS.indexOf(v) !== -1) return v;
+  return '';
 }
 
+// normaliza campos de body para strings e aplica trim
 function applyBodyNormalizers(req, _res, next) {
-  var b = req.body || (req.body = {});
-
-  // Campos opcionais: string vazia -> null
-  var optFields = ['sender_phone', 'sender_email', 'callback_time', 'notes'];
-  for (var i = 0; i < optFields.length; i++) {
-    var k = optFields[i];
-    if (Object.prototype.hasOwnProperty.call(b, k)) {
-      b[k] = emptyToNull(b[k]);
-    }
-  }
-
-  if (Object.prototype.hasOwnProperty.call(b, 'status')) {
-    var normalizedStatus = normalizeStatus(b.status);
-    b.status = normalizedStatus || '';
-  }
-
-  if (Object.prototype.hasOwnProperty.call(b, 'call_date') && typeof b.call_date === 'string') {
-    b.call_date = b.call_date.trim();
-  }
-  if (Object.prototype.hasOwnProperty.call(b, 'call_time') && typeof b.call_time === 'string') {
-    b.call_time = b.call_time.trim();
-  }
-
+  var b = req.body || {};
+  [
+    'recipient',
+    'sender_name',
+    'sender_phone',
+    'sender_email',
+    'subject',
+    'message',
+    'status',
+    'call_date',
+    'call_time',
+    'callback_time',
+    'notes'
+  ].forEach(function (k) {
+    if (b[k] === undefined || b[k] === null) return;
+    if (typeof b[k] !== 'string') b[k] = String(b[k]);
+    b[k] = b[k].trim();
+  });
+  // normaliza status, se presente
+  if (b.status) b.status = normalizeStatus(b.status);
   next();
 }
 
+// normaliza query strings
 function applyQueryNormalizers(req, _res, next) {
-  var q = req.query || (req.query = {});
-  if (Object.prototype.hasOwnProperty.call(q, 'status')) {
-    if (isBlank(q.status)) {
-      delete q.status;
-    } else {
-      q.status = normalizeStatus(q.status);
-    }
-  }
-  if (Object.prototype.hasOwnProperty.call(q, 'limit'))  { q.limit  = String(q.limit).trim(); }
-  if (Object.prototype.hasOwnProperty.call(q, 'offset')) { q.offset = String(q.offset).trim(); }
-  var optionalFields = ['start_date', 'end_date', 'recipient'];
-  for (var i = 0; i < optionalFields.length; i++) {
-    var field = optionalFields[i];
-    if (Object.prototype.hasOwnProperty.call(q, field)) {
-      var value = toStr(q[field]).trim();
-      if (!value) {
-        delete q[field];
-      } else {
-        q[field] = value;
-      }
-    }
+  var q = req.query || {};
+  Object.keys(q).forEach(function (k) {
+    if (typeof q[k] === 'string') q[k] = q[k].trim();
+  });
+  if (q.status) q.status = normalizeStatus(q.status);
+  next();
+}
+
+// regex simples para data YYYY-MM-DD
+var dateRegex = /^\d{4}-\d{2}-\d{2}$/;
+
+// -------------------------------------------------------------
+// Tratamento padrão de erros de validação
+// -------------------------------------------------------------
+function handleValidationErrors(req, res, next) {
+  var errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res.status(400).json({
+      success: false,
+      error: 'Dados inválidos',
+      details: errors.array()
+    });
   }
   next();
 }
 
-// ---------------------------------------------------------------------------
-// Regras básicas reutilizáveis
-// ---------------------------------------------------------------------------
-var dateRegex = /^\d{4}-\d{2}-\d{2}$/; // YYYY-MM-DD (validação simples)
-var timeRegex = /^\d{2}:\d{2}$/;       // HH:MM
+// -------------------------------------------------------------
+// Validators de Messages
+// -------------------------------------------------------------
 
-function commonCreateAndUpdateRules() {
-  return [
-    body('call_date')
-      .notEmpty().withMessage('Data da ligação é obrigatória')
-      .bail()
-      .matches(dateRegex).withMessage('Data deve estar no formato válido (YYYY-MM-DD)'),
-
-    body('call_time')
-      .notEmpty().withMessage('Hora da ligação é obrigatória')
-      .bail()
-      .matches(timeRegex).withMessage('Hora deve estar no formato HH:MM'),
-
-    body('recipient').notEmpty().withMessage('Destinatário é obrigatório'),
-    body('sender_name').notEmpty().withMessage('Remetente é obrigatório'),
-    body('subject').notEmpty().withMessage('Assunto é obrigatório'),
-
-    body('sender_email')
-      .optional({ checkFalsy: true })
-      .isEmail().withMessage('E-mail deve ter formato válido'),
-
-    body('sender_phone').optional({ checkFalsy: true }).isLength({ max: 50 }),
-    body('callback_time').optional({ checkFalsy: true }).isLength({ max: 100 }),
-
-    body('status')
-      .optional({ checkFalsy: true })
-      .custom(function(value) {
-        var normalized = normalizeStatus(value);
-        if (normalized && ALLOWED_STATUS.indexOf(normalized) === -1) {
-          throw new Error('Status deve ser: pending, in_progress ou resolved');
-        }
-        return true;
-      })
-      .customSanitizer(function(value) {
-        return normalizeStatus(value);
-      }),
-  ];
-}
-
-// ---------------------------------------------------------------------------
-// Validators exportados
-// ---------------------------------------------------------------------------
+// Criação de recado
 var validateCreateMessage = [
-  applyBodyNormalizers
-].concat(commonCreateAndUpdateRules());
+  applyBodyNormalizers,
 
+  body('message')
+    .notEmpty().withMessage('Mensagem é obrigatória')
+    .bail()
+    .isLength({ max: 5000 }).withMessage('Mensagem muito longa'),
+
+  body('status')
+    .optional({ checkFalsy: true })
+    .custom(function (value) {
+      var v = normalizeStatus(value);
+      if (!v || ALLOWED_STATUS.indexOf(v) === -1) throw new Error('Status inválido');
+      return true;
+    })
+    .customSanitizer(function (value) { return normalizeStatus(value); }),
+
+  body('recipient')
+    .optional({ checkFalsy: true })
+    .isLength({ max: 255 }).withMessage('Destinatário muito longo'),
+
+  body('sender_email')
+    .optional({ checkFalsy: true })
+    .isEmail().withMessage('Email inválido')
+    .normalizeEmail(),
+
+  body('sender_phone')
+    .optional({ checkFalsy: true })
+    .isLength({ max: 60 }).withMessage('Telefone inválido'),
+
+  body('subject')
+    .optional({ checkFalsy: true })
+    .isLength({ max: 255 }).withMessage('Assunto muito longo'),
+
+  body('call_date')
+    .optional({ checkFalsy: true })
+    .matches(dateRegex).withMessage('Data da chamada inválida (YYYY-MM-DD)'),
+
+  body('call_time')
+    .optional({ checkFalsy: true })
+    .isLength({ max: 10 }).withMessage('Horário inválido'),
+
+  body('callback_time')
+    .optional({ checkFalsy: true })
+    .isLength({ max: 30 }).withMessage('Horário de retorno inválido')
+];
+
+// Atualização completa
 var validateUpdateMessage = [
-  applyBodyNormalizers
-].concat(commonCreateAndUpdateRules());
+  applyBodyNormalizers,
 
+  body('message')
+    .optional({ checkFalsy: true })
+    .isLength({ max: 5000 }).withMessage('Mensagem muito longa'),
+
+  body('status')
+    .optional({ checkFalsy: true })
+    .custom(function (value) {
+      var v = normalizeStatus(value);
+      if (v && ALLOWED_STATUS.indexOf(v) === -1) throw new Error('Status inválido');
+      return true;
+    })
+    .customSanitizer(function (value) { return normalizeStatus(value); }),
+
+  body('recipient')
+    .optional({ checkFalsy: true })
+    .isLength({ max: 255 }).withMessage('Destinatário muito longo'),
+
+  body('sender_email')
+    .optional({ checkFalsy: true })
+    .isEmail().withMessage('Email inválido')
+    .normalizeEmail(),
+
+  body('sender_phone')
+    .optional({ checkFalsy: true })
+    .isLength({ max: 60 }).withMessage('Telefone inválido'),
+
+  body('subject')
+    .optional({ checkFalsy: true })
+    .isLength({ max: 255 }).withMessage('Assunto muito longo'),
+
+  body('call_date')
+    .optional({ checkFalsy: true })
+    .matches(dateRegex).withMessage('Data da chamada inválida (YYYY-MM-DD)'),
+
+  body('call_time')
+    .optional({ checkFalsy: true })
+    .isLength({ max: 10 }).withMessage('Horário inválido'),
+
+  body('callback_time')
+    .optional({ checkFalsy: true })
+    .isLength({ max: 30 }).withMessage('Horário de retorno inválido')
+];
+
+// Atualização apenas de status
 var validateUpdateStatus = [
   applyBodyNormalizers,
   body('status')
     .notEmpty().withMessage('Status é obrigatório')
     .bail()
-    .custom(function(value) {
-      var normalized = normalizeStatus(value);
-      if (!normalized || ALLOWED_STATUS.indexOf(normalized) === -1) {
-        throw new Error('Status deve ser: pending, in_progress ou resolved');
-      }
+    .custom(function (value) {
+      var v = normalizeStatus(value);
+      if (!v || ALLOWED_STATUS.indexOf(v) === -1) throw new Error('Status inválido');
       return true;
     })
-    .customSanitizer(function(value) {
-      return normalizeStatus(value);
-    })
+    .customSanitizer(function (value) { return normalizeStatus(value); })
 ];
 
-// middleware/validation.js
-// ...
-const { query, param, body, validationResult } = require('express-validator');
+// ID de rota /:id
+var validateId = [
+  param('id')
+    .notEmpty().withMessage('ID é obrigatório')
+    .bail()
+    .isInt({ min: 1 }).withMessage('ID inválido')
+    .toInt()
+];
 
-// Validação permissiva para listagem de recados (suporta filtros opcionais)
-// Defaults: limit=10, offset=0, order_by=created_at, order=desc
-exports.validateQueryMessages = [
+// -------------------------------------------------------------
+// Listagem: validação PERMISSIVA com defaults
+// (evita 400 no Dashboard para "Recados Recentes")
+// -------------------------------------------------------------
+var validateQueryMessages = [
+  applyQueryNormalizers,
+
   // paginação
   query('limit')
     .optional({ checkFalsy: true, nullable: true })
     .isInt({ min: 1, max: 50 }).withMessage('limit inválido')
     .toInt()
-    .customSanitizer(v => (v && v >= 1 && v <= 50) ? v : 10),
+    .customSanitizer(function (v) { return (v && v >= 1 && v <= 50) ? v : 10; }),
 
   query('offset')
     .optional({ checkFalsy: true, nullable: true })
     .isInt({ min: 0 }).withMessage('offset inválido')
     .toInt()
-    .customSanitizer(v => (typeof v === 'number' && v >= 0) ? v : 0),
+    .customSanitizer(function (v) { return (typeof v === 'number' && v >= 0) ? v : 0; }),
 
-  // filtros (todos opcionais)
+  // filtros
   query('status')
     .optional({ checkFalsy: true, nullable: true })
-    .customSanitizer(v => String(v || '').toLowerCase().trim())
-    .isIn(['pending', 'in_progress', 'resolved']).withMessage('Status inválido'),
+    .customSanitizer(function (v) { return normalizeStatus(v); })
+    .custom(function (v) {
+      if (!v) return true; // opcional
+      if (ALLOWED_STATUS.indexOf(v) === -1) throw new Error('Status inválido');
+      return true;
+    }),
 
   query('recipient')
     .optional({ checkFalsy: true, nullable: true })
@@ -189,61 +247,38 @@ exports.validateQueryMessages = [
   // datas (opcionais no formato YYYY-MM-DD)
   query('start_date')
     .optional({ checkFalsy: true, nullable: true })
-    .matches(/^\d{4}-\d{2}-\d{2}$/).withMessage('start_date inválida'),
+    .matches(dateRegex).withMessage('start_date inválida'),
 
   query('end_date')
     .optional({ checkFalsy: true, nullable: true })
-    .matches(/^\d{4}-\d{2}-\d{2}$/).withMessage('end_date inválida')
-    .custom((value, { req }) => {
-      const start = req?.query?.start_date;
-      if (value && start && value < start) {
-        throw new Error('end_date deve ser igual ou posterior a start_date');
-      }
+    .matches(dateRegex).withMessage('end_date inválida')
+    .custom(function (value, meta) {
+      var req = (meta && meta.req) ? meta.req : {};
+      var start = (req.query && req.query.start_date) ? req.query.start_date : null;
+      if (value && start && value < start) throw new Error('end_date deve ser igual ou posterior a start_date');
       return true;
     }),
 
-  // ordenação (opcional, com defaults)
+  // ordenação
   query('order_by')
     .optional({ checkFalsy: true, nullable: true })
     .isIn(['created_at', 'updated_at', 'status']).withMessage('order_by inválido')
-    .customSanitizer(v => v || 'created_at'),
+    .customSanitizer(function (v) { return v || 'created_at'; }),
 
   query('order')
     .optional({ checkFalsy: true, nullable: true })
-    .customSanitizer(v => (String(v || 'desc').toLowerCase() === 'asc' ? 'asc' : 'desc')),
+    .customSanitizer(function (v) { return (String(v || 'desc').toLowerCase() === 'asc' ? 'asc' : 'desc'); })
 ];
 
-var validateId = [
-  param('id').isInt({ min: 1 }).withMessage('ID inválido')
-];
-
-function handleValidationErrors(req, res, next) {
-  var result = validationResult(req);
-  if (result.isEmpty()) return next();
-  return res.status(400).json({
-    success: false,
-    error: 'Dados inválidos',
-    details: result.array(),
-  });
-}
-
+// -------------------------------------------------------------
+// Exports
+// -------------------------------------------------------------
 module.exports = {
-  validateCreateMessage: validateCreateMessage,
-  validateUpdateMessage: validateUpdateMessage,
-  validateUpdateStatus: validateUpdateStatus,
-  validateQueryMessages: validateQueryMessages,
-  validateId: validateId,
-  handleValidationErrors: handleValidationErrors,
-
-  // helpers expostos para testes/unit
-  _normalize: {
-    status: normalizeStatus,
-    emptyToNull: emptyToNull
-  }
+  handleValidationErrors,
+  validateCreateMessage,
+  validateUpdateMessage,
+  validateUpdateStatus,
+  validateId,
+  validateQueryMessages
 };
 
-// Compat aliases temporários
-module.exports.validateCreateRecado = module.exports.validateCreateMessage;
-module.exports.validateUpdateRecado = module.exports.validateUpdateMessage;
-module.exports.validateUpdateSituacao = module.exports.validateUpdateStatus;
-module.exports.validateQueryRecados = module.exports.validateQueryMessages;

--- a/models/message.js
+++ b/models/message.js
@@ -381,13 +381,11 @@ async function statsByStatus() {
   }));
 }
 
-// dentro do module.exports = { ... }  (mantenha vírgula ao final)
-statsByMonth: async () => {
-  // Garante helper de DB
-  const database = require('../config/database');
-  const db = () => database.db();
-
-  // Série dos últimos 12 meses por created_at (compatível com PostgreSQL)
+// ============================================================================
+// Estatísticas: série mensal dos últimos 12 meses (compatível com PostgreSQL)
+// Comentários em pt-BR; identificadores em inglês.
+// ----------------------------------------------------------------------------
+async function statsByMonth() {
   const sql = `
     WITH months AS (
       SELECT date_trunc('month', NOW()) - (INTERVAL '1 month' * generate_series(0, 11)) AS m
@@ -401,10 +399,10 @@ statsByMonth: async () => {
     GROUP BY m
     ORDER BY m;
   `;
-
   const rows = await db().prepare(sql).all();
   return rows.map(r => ({ month: r.month, total: Number(r.total || 0) }));
-},
+}
+// ============================================================================
 
 module.exports = {
   create,

--- a/models/message.js
+++ b/models/message.js
@@ -381,8 +381,13 @@ async function statsByStatus() {
   }));
 }
 
-// Últimos 12 meses por created_at (compatível com PostgreSQL)
-exports.statsByMonth = async () => {
+// dentro do module.exports = { ... }  (mantenha vírgula ao final)
+statsByMonth: async () => {
+  // Garante helper de DB
+  const database = require('../config/database');
+  const db = () => database.db();
+
+  // Série dos últimos 12 meses por created_at (compatível com PostgreSQL)
   const sql = `
     WITH months AS (
       SELECT date_trunc('month', NOW()) - (INTERVAL '1 month' * generate_series(0, 11)) AS m
@@ -396,9 +401,10 @@ exports.statsByMonth = async () => {
     GROUP BY m
     ORDER BY m;
   `;
-  const rows = await db().prepare(sql).all(); // sem parâmetros
+
+  const rows = await db().prepare(sql).all();
   return rows.map(r => ({ month: r.month, total: Number(r.total || 0) }));
-};
+},
 
 module.exports = {
   create,

--- a/models/message.js
+++ b/models/message.js
@@ -1,3 +1,6 @@
+// models/message.js
+// Comentários em pt-BR; identificadores em inglês.
+
 const database = require('../config/database');
 
 function db() {
@@ -8,6 +11,7 @@ function ph(index) {
   return database.placeholder(index);
 }
 
+// ---------------------------- Status e labels -------------------------------
 const STATUS_EN_TO_PT = {
   pending: 'pendente',
   in_progress: 'em_andamento',
@@ -41,15 +45,14 @@ const LEGACY_STATUS_ALIASES = {
   closed: 'resolved',
 };
 
+// ---------------------------- Utils de normalização ------------------------
 function toString(value) {
   if (value === undefined || value === null) return '';
   return String(value);
 }
-
 function trim(value) {
   return toString(value).trim();
 }
-
 function emptyToNull(value) {
   const v = trim(value);
   return v === '' ? null : v;
@@ -68,12 +71,10 @@ function normalizeStatus(raw) {
   if (LEGACY_STATUS_ALIASES[normalized]) return LEGACY_STATUS_ALIASES[normalized];
   return 'pending';
 }
-
 function ensureStatus(value) {
   const normalized = normalizeStatus(value);
   return STATUS_VALUES.includes(normalized) ? normalized : 'pending';
 }
-
 function translateStatusForQuery(status) {
   if (!status) return null;
   const normalized = normalizeStatus(status);
@@ -83,6 +84,7 @@ function translateStatusForQuery(status) {
   };
 }
 
+// ---------------------------- Normalização de payload ----------------------
 function normalizePayload(payload = {}) {
   const messageContent = trim(payload.message || payload.notes || '');
   const statusProvided = Object.prototype.hasOwnProperty.call(payload, 'status');
@@ -104,14 +106,14 @@ function normalizePayload(payload = {}) {
   };
 }
 
-function attachTimestamps(payload, source = {}) {
+function attachTimestamps(_payload, source = {}) {
   return {
-    ...payload,
     created_at: emptyToNull(source.created_at),
     updated_at: emptyToNull(source.updated_at),
   };
 }
 
+// ---------------------------- Mapeamento de colunas ------------------------
 const SELECT_COLUMNS = `
   id,
   call_date,
@@ -149,6 +151,16 @@ function mapRow(row) {
   };
 }
 
+// ---------------------------- Filtros SQL ----------------------------------
+// date_ref: usa call_date (YYYY-MM-DD) válido; senão, created_at::date
+const DATE_REF_SQL = `
+  CASE
+    WHEN call_date IS NOT NULL AND call_date ~ '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'
+      THEN call_date::date
+    ELSE created_at::date
+  END
+`;
+
 function buildFilters({ status, startDate, endDate, recipient }, startIndex = 1) {
   let index = startIndex;
   const clauses = [];
@@ -161,13 +173,14 @@ function buildFilters({ status, startDate, endDate, recipient }, startIndex = 1)
   }
 
   if (startDate) {
-    clauses.push(`DATE(COALESCE(NULLIF(TRIM(call_date), ''), CAST(created_at AS TEXT))) >= DATE(${ph(index)})`);
+    clauses.push(`${DATE_REF_SQL} >= ${ph(index)}::date`);
     params.push(startDate);
     index += 1;
   }
 
   if (endDate) {
-    clauses.push(`DATE(COALESCE(NULLIF(TRIM(call_date), ''), CAST(created_at AS TEXT))) <= DATE(${ph(index)})`);
+    // inclusivo no dia final
+    clauses.push(`${DATE_REF_SQL} <= ${ph(index)}::date`);
     params.push(endDate);
     index += 1;
   }
@@ -185,243 +198,11 @@ function buildFilters({ status, startDate, endDate, recipient }, startIndex = 1)
   };
 }
 
+// ---------------------------- CRUD / Listagem ------------------------------
 async function create(payload) {
   const normalized = normalizePayload(payload);
   const timestamps = attachTimestamps({}, payload);
   const data = {
     ...normalized.data,
-    status: normalized.statusProvided && normalized.data.status ? normalized.data.status : 'pending',
-  };
-  const baseFields = [
-    'call_date',
-    'call_time',
-    'recipient',
-    'sender_name',
-    'sender_phone',
-    'sender_email',
-    'subject',
-    'message',
-    'status',
-    'callback_time',
-    'notes',
-  ];
-  const fields = [...baseFields];
-  const values = baseFields.map((field) => data[field]);
-  if (timestamps.created_at) {
-    fields.push('created_at');
-    values.push(timestamps.created_at);
-  }
-  if (timestamps.updated_at) {
-    fields.push('updated_at');
-    values.push(timestamps.updated_at);
-  }
-  const stmt = db().prepare(`
-    INSERT INTO messages (
-      ${fields.join(',\n      ')}
-    ) VALUES (
-      ${fields.map((_, index) => ph(index + 1)).join(', ')}
-    )
-    RETURNING ${SELECT_COLUMNS}
-  `);
-  const row = await stmt.get(values);
-  return row?.id || null;
-}
+    status
 
-async function findById(id) {
-  const stmt = db().prepare(`
-    SELECT ${SELECT_COLUMNS}
-      FROM messages
-     WHERE id = ${ph(1)}
-     LIMIT 1
-  `);
-  const row = await stmt.get([id]);
-  return mapRow(row);
-}
-
-async function update(id, payload) {
-  const normalized = normalizePayload(payload);
-  const fields = [
-    'call_date',
-    'call_time',
-    'recipient',
-    'sender_name',
-    'sender_phone',
-    'sender_email',
-    'subject',
-    'message',
-    'callback_time',
-    'notes',
-  ];
-  const values = fields.map((field) => normalized.data[field]);
-  const assignments = fields.map((field, idx) => `${field} = ${ph(idx + 1)}`);
-  const statusIndex = assignments.length + 1;
-  assignments.push(`status = COALESCE(${ph(statusIndex)}, status)`);
-  assignments.push('updated_at = CURRENT_TIMESTAMP');
-  const stmt = db().prepare(`
-    UPDATE messages
-       SET ${assignments.join(', ')}
-     WHERE id = ${ph(statusIndex + 1)}
-  `);
-  const params = [...values, normalized.statusProvided ? normalized.data.status : null, id];
-  const result = await stmt.run(params);
-  return result.changes > 0;
-}
-
-async function updateStatus(id, status) {
-  const stmt = db().prepare(`
-    UPDATE messages
-       SET status = ${ph(1)},
-           updated_at = CURRENT_TIMESTAMP
-     WHERE id = ${ph(2)}
-  `);
-  const result = await stmt.run([ensureStatus(status), id]);
-  return result.changes > 0;
-}
-
-async function remove(id) {
-  const stmt = db().prepare(`DELETE FROM messages WHERE id = ${ph(1)}`);
-  const result = await stmt.run([id]);
-  return result.changes > 0;
-}
-
-async function list({ limit = 10, offset = 0, status, start_date, end_date, recipient } = {}) {
-  const parsedLimit = Number(limit);
-  const parsedOffset = Number(offset);
-  const sanitizedLimit = Number.isFinite(parsedLimit) && parsedLimit > 0 ? Math.min(parsedLimit, 200) : 10;
-  const sanitizedOffset = Number.isFinite(parsedOffset) && parsedOffset >= 0 ? parsedOffset : 0;
-  const statusFilter = translateStatusForQuery(status);
-  const startDate = trim(start_date);
-  const endDate = trim(end_date);
-  const recipientFilter = trim(recipient);
-
-  const filters = buildFilters({
-    status: statusFilter,
-    startDate: startDate || null,
-    endDate: endDate || null,
-    recipient: recipientFilter || null,
-  });
-
-  const rowsStmt = db().prepare(`
-    SELECT ${SELECT_COLUMNS}
-      FROM messages
-      ${filters.clause}
-  ORDER BY id DESC
-     LIMIT ${ph(filters.nextIndex)} OFFSET ${ph(filters.nextIndex + 1)}
-  `);
-  const rows = await rowsStmt.all([...filters.params, sanitizedLimit, sanitizedOffset]);
-
-  const countFilters = buildFilters({
-    status: statusFilter,
-    startDate: startDate || null,
-    endDate: endDate || null,
-    recipient: recipientFilter || null,
-  });
-  const countStmt = db().prepare(`SELECT COUNT(*) AS total FROM messages ${countFilters.clause}`);
-  const countRow = await countStmt.get(countFilters.params);
-  const total = Number(countRow?.total || 0);
-
-  return rows.map(mapRow);
-}
-
-async function listRecent(limit = 10) {
-  return list({ limit });
-}
-
-async function stats() {
-  const totalRow = await db().prepare('SELECT COUNT(*) AS count FROM messages').get();
-  const rows = await db().prepare('SELECT status, COUNT(*) AS count FROM messages GROUP BY status').all();
-  const counters = rows.reduce((acc, row) => {
-    const normalized = ensureStatus(row.status);
-    acc[normalized] = (acc[normalized] || 0) + Number(row.count || 0);
-    return acc;
-  }, {});
-
-  return {
-    total: Number(totalRow?.count || 0),
-    pending: counters.pending || 0,
-    in_progress: counters.in_progress || 0,
-    resolved: counters.resolved || 0,
-  };
-}
-
-async function statsByRecipient({ limit = 10 } = {}) {
-  const parsedLimit = Number(limit);
-  const sanitizedLimit = Number.isFinite(parsedLimit) && parsedLimit > 0 ? Math.min(parsedLimit, 100) : 10;
-  const stmt = db().prepare(`
-    SELECT
-      COALESCE(NULLIF(TRIM(recipient), ''), 'Não informado') AS recipient,
-      COUNT(*) AS count
-      FROM messages
-  GROUP BY recipient
-  ORDER BY count DESC, recipient ASC
-     LIMIT ${ph(1)}
-  `);
-  const rows = await stmt.all([sanitizedLimit]);
-  return rows.map(row => ({ recipient: row.recipient, count: Number(row.count || 0) }));
-}
-
-async function statsByStatus() {
-  const rows = await db().prepare(`
-    SELECT status, COUNT(*) AS count
-      FROM messages
-  GROUP BY status
-  `).all();
-  const totals = STATUS_VALUES.reduce((acc, status) => {
-    acc[status] = 0;
-    return acc;
-  }, {});
-  for (const row of rows) {
-    const normalized = ensureStatus(row.status);
-    totals[normalized] = (totals[normalized] || 0) + Number(row.count || 0);
-  }
-  return STATUS_VALUES.map(status => ({
-    status,
-    label: STATUS_LABELS_PT[status] || status,
-    count: totals[status] || 0,
-  }));
-}
-
-// ============================================================================
-// Estatísticas: série mensal dos últimos 12 meses (compatível com PostgreSQL)
-// Comentários em pt-BR; identificadores em inglês.
-// ----------------------------------------------------------------------------
-async function statsByMonth() {
-  const sql = `
-    WITH months AS (
-      SELECT date_trunc('month', NOW()) - (INTERVAL '1 month' * generate_series(0, 11)) AS m
-    )
-    SELECT
-      to_char(m, 'YYYY-MM') AS month,
-      COALESCE(COUNT(ms.id), 0)::int AS total
-    FROM months
-    LEFT JOIN messages AS ms
-      ON date_trunc('month', ms.created_at) = date_trunc('month', m)
-    GROUP BY m
-    ORDER BY m;
-  `;
-  const rows = await db().prepare(sql).all();
-  return rows.map(r => ({ month: r.month, total: Number(r.total || 0) }));
-}
-// ============================================================================
-
-module.exports = {
-  create,
-  findById,
-  update,
-  updateStatus,
-  remove,
-  list,
-  listRecent,
-  stats,
-  statsByRecipient,
-  statsByStatus,
-  statsByMonth,
-  normalizeStatus,
-  STATUS_VALUES,
-  STATUS_LABELS_PT,
-  STATUS_TRANSLATIONS: {
-    enToPt: { ...STATUS_EN_TO_PT },
-    ptToEn: { ...STATUS_PT_TO_EN },
-    labelsPt: { ...STATUS_LABELS_PT },
-  },
-};

--- a/models/stats.js
+++ b/models/stats.js
@@ -1,0 +1,74 @@
+// models/stats.js
+// Comentários em pt-BR; identificadores em inglês.
+// Camada de leitura para estatísticas agregadas da tabela "messages".
+
+const database = require('../config/database');
+
+function db() {
+  // Retorna o adaptador corrente (PG). O projeto expõe database.db() para queries preparadas.
+  return database.db();
+}
+
+// Estatísticas gerais no intervalo informado (por created_at)
+// Retorna chaves esperadas pelo front: { total, pendente, em_andamento, resolvido }
+exports.getMessagesStats = async ({ startAt, endAt }) => {
+  const sql = `
+    SELECT
+      COUNT(*)                                                   AS total,
+      COUNT(*) FILTER (WHERE status = 'pending')                 AS pendente,
+      COUNT(*) FILTER (WHERE status = 'in_progress')             AS em_andamento,
+      COUNT(*) FILTER (WHERE status = 'resolved')                AS resolvido
+    FROM messages
+    WHERE created_at >= $1 AND created_at < $2
+  `;
+  const row = await db().prepare(sql).get(startAt, endAt);
+  return {
+    total: Number(row?.total || 0),
+    pendente: Number(row?.pendente || 0),
+    em_andamento: Number(row?.em_andamento || 0),
+    resolvido: Number(row?.resolvido || 0),
+  };
+};
+
+// Agrupado por status (para gráficos/relatórios)
+exports.getStatsByStatus = async () => {
+  const sql = `
+    SELECT status, COUNT(*)::int AS total
+    FROM messages
+    GROUP BY status
+    ORDER BY status
+  `;
+  const rows = await db().prepare(sql).all();
+  return rows.map(r => ({ status: r.status, total: Number(r.total || 0) }));
+};
+
+// Agrupado por destinatário
+exports.getStatsByRecipient = async () => {
+  const sql = `
+    SELECT COALESCE(recipient, 'Sem destinatário') AS recipient, COUNT(*)::int AS total
+    FROM messages
+    GROUP BY 1
+    ORDER BY 1
+  `;
+  const rows = await db().prepare(sql).all();
+  return rows.map(r => ({ recipient: r.recipient, total: Number(r.total || 0) }));
+};
+
+// Últimos N meses (fixo em 12 para evitar problemas com parâmetros no adapter)
+exports.getStatsByMonth = async () => {
+  const sql = `
+    WITH months AS (
+      SELECT date_trunc('month', NOW()) - (INTERVAL '1 month' * generate_series(0, 11)) AS m
+    )
+    SELECT to_char(m, 'YYYY-MM') AS month,
+           COALESCE(COUNT(messages.id), 0)::int AS total
+    FROM months
+    LEFT JOIN messages
+      ON date_trunc('month', messages.created_at) = date_trunc('month', m)
+    GROUP BY m
+    ORDER BY m
+  `;
+  const rows = await db().prepare(sql).all();
+  return rows.map(r => ({ month: r.month, total: Number(r.total || 0) }));
+};
+

--- a/routes/api.js
+++ b/routes/api.js
@@ -1,9 +1,11 @@
 // routes/api.js
 // Rotas de API em inglês (payloads/keys) com mensagens ao usuário em pt-BR.
 
+
 const express = require('express');
 const router = express.Router();
 
+const statsController = require('../controllers/statsController');
 const messageController = require('../controllers/messageController');
 const userController = require('../controllers/userController');
 const database = require('../config/database'); // <— adicionado para health/db
@@ -18,6 +20,11 @@ const {
   handleValidationErrors,
 } = require('../middleware/validation');
 
+
+// ----------------------------------------
+// Estatísticas para dashboard/relatórios
+// ----------------------------------------
+
 // ---------------------------------------------------------------------------
 // Messages
 // ---------------------------------------------------------------------------
@@ -29,7 +36,7 @@ router.get(
 );
 
 router.get(
-  '/messages/:id',
+  '/messages/:id(\d+)',
   ...validateId,
   handleValidationErrors,
   messageController.getById
@@ -43,7 +50,7 @@ router.post(
 );
 
 router.put(
-  '/messages/:id',
+  '/messages/:id(\d+)',
   ...validateId,
   ...validateUpdateMessage,
   handleValidationErrors,
@@ -51,7 +58,7 @@ router.put(
 );
 
 router.patch(
-  '/messages/:id/status',
+  '/messages/:id(\d+)/status',
   ...validateId,
   ...validateUpdateStatus,
   handleValidationErrors,
@@ -59,16 +66,12 @@ router.patch(
 );
 
 router.delete(
-  '/messages/:id',
+  '/messages/:id(\d+)',
   ...validateId,
   handleValidationErrors,
   messageController.remove
 );
 
-router.get('/messages/stats', messageController.stats);
-router.get('/stats/by-recipient', messageController.statsByRecipient);
-router.get('/stats/by-status', messageController.statsByStatus);
-router.get('/stats/by-month', messageController.statsByMonth);
 
 // ---------------------------------------------------------------------------
 // Users
@@ -76,6 +79,7 @@ router.get('/stats/by-month', messageController.statsByMonth);
 router.get('/users', userController.list);
 router.post('/users', userController.create);
 router.patch('/users/:id/active', userController.setActive);
+
 
 // ---------------------------------------------------------------------------
 // Healthcheck e utilitários
@@ -87,7 +91,7 @@ router.get('/csrf', csrfProtection, (req, res) => {
   res.json({ success: true, data: { token } });
 });
 
-// Novo: health do DB (mostra driver e versão do banco em execução no processo)
+// Novo: h  ealth do DB (mostra driver e versão do banco em execução no processo)
 router.get('/health/db', async (_req, res) => {
   try {
     const db = database.db();

--- a/routes/api.js
+++ b/routes/api.js
@@ -1,129 +1,186 @@
 // routes/api.js
-// Rotas de API em inglês (keys) com mensagens/valores em pt-BR.
 // Comentários em pt-BR; identificadores em inglês.
+// Rotas REST (/api/*) — CRUD de messages, estatísticas e health do DB.
 
 const express = require('express');
 const router = express.Router();
 
+// Controllers
 const messageController = require('../controllers/messageController');
-const userController = require('../controllers/userController');
-const database = require('../config/database'); // usado no /health/db
+const userController    = require('../controllers/userController'); // opcional
+
+// Handlers de stats com require tardio (evita cache quebrado e garante função)
+const statsHandlers = {
+  messagesStats: (req, res, next) => {
+    try {
+      const c = require('../controllers/statsController');
+      return (typeof c.messagesStats === 'function')
+        ? c.messagesStats(req, res, next)
+        : next(new Error('statsController.messagesStats não é função'));
+    } catch (e) { return next(e); }
+  },
+  byStatus: (req, res, next) => {
+    try {
+      const c = require('../controllers/statsController');
+      return (typeof c.byStatus === 'function')
+        ? c.byStatus(req, res, next)
+        : next(new Error('statsController.byStatus não é função'));
+    } catch (e) { return next(e); }
+  },
+  byRecipient: (req, res, next) => {
+    try {
+      const c = require('../controllers/statsController');
+      return (typeof c.byRecipient === 'function')
+        ? c.byRecipient(req, res, next)
+        : next(new Error('statsController.byRecipient não é função'));
+    } catch (e) { return next(e); }
+  },
+  byMonth: (req, res, next) => {
+    try {
+      const c = require('../controllers/statsController');
+      return (typeof c.byMonth === 'function')
+        ? c.byMonth(req, res, next)
+        : next(new Error('statsController.byMonth não é função'));
+    } catch (e) { return next(e); }
+  }
+};
+
+// Infra
+const database       = require('../config/database'); // /health/db
 const csrfProtection = require('../middleware/csrf');
 
+// Validações
 const {
   validateCreateMessage,
   validateUpdateMessage,
   validateUpdateStatus,
-  validateQueryMessages,
-  validateId,
-  handleValidationErrors,
+  validateListMessages,
+  validateIdParam,
+  handleValidation
 } = require('../middleware/validation');
 
-/**
- * IMPORTANTE SOBRE PATHS:
- * Este router é montado em server.js com app.use('/api', router).
- * Logo, aqui dentro os caminhos NÃO devem começar com /api.
- */
+/* -------------------------------------------------------------------- *
+ * Helpers defensivos para registro de rotas
+ * - Achata arrays de middlewares e garante que todo item seja função
+ * - Se não for função, registra um middleware que loga erro e chama next(err)
+ * -------------------------------------------------------------------- */
+function normalizeHandlers(handlers, label) {
+  const flat = handlers.flatMap(h => Array.isArray(h) ? h : [h]);
+  return flat.map((mw, i) => {
+    if (typeof mw === 'function') return mw;
+    const type = Object.prototype.toString.call(mw);
+    return (req, res, next) => {
+      const msg = `[router] ${label}: middleware #${i} inválido (tipo=${type})`;
+      console.error(msg);
+      next(new Error(msg));
+    };
+  });
+}
 
-/* ----------------------------------------
- * Estatísticas para dashboard/relatórios
- * (colocadas ANTES das rotas com :id para evitar colisão)
-/* --------------------------------------*/
-router.get('/messages/stats', messageController.stats);
-router.get('/stats/by-status', messageController.statsByStatus);
-router.get('/stats/by-recipient', messageController.statsByRecipient);
-router.get('/stats/by-month', messageController.statsByMonth);
+function add(method, path, ...handlers) {
+  const label = `${method.toUpperCase()} ${path}`;
+  const fns = normalizeHandlers(handlers, label);
+  router[method](path, ...fns);
+}
 
-/* ---------------------------------------------------------------------------
- * Messages (CRUD)
- * -------------------------------------------------------------------------*/
-router.get(
-  '/messages',
-  ...validateQueryMessages,
-  handleValidationErrors,
-  messageController.list
-);
+const GET    = (...args) => add('get',    ...args);
+const POST   = (...args) => add('post',   ...args);
+const PUT    = (...args) => add('put',    ...args);
+const PATCH  = (...args) => add('patch',  ...args);
+const DELETE = (...args) => add('delete', ...args);
 
-router.get(
-  '/messages/:id',
-  ...validateId,
-  handleValidationErrors,
-  messageController.getById
-);
-
-router.post(
-  '/messages',
-  ...validateCreateMessage,
-  handleValidationErrors,
-  messageController.create
-);
-
-router.put(
-  '/messages/:id',
-  ...validateId,
-  ...validateUpdateMessage,
-  handleValidationErrors,
-  messageController.update
-);
-
-router.patch(
-  '/messages/:id/status',
-  ...validateId,
-  ...validateUpdateStatus,
-  handleValidationErrors,
-  messageController.updateStatus
-);
-
-router.delete(
-  '/messages/:id',
-  ...validateId,
-  handleValidationErrors,
-  messageController.remove
-);
-
-/* ---------------------------------------------------------------------------
- * Users
- * -------------------------------------------------------------------------*/
-router.get('/users', userController.list);
-router.post('/users', userController.create);
-router.patch('/users/:id/active', userController.setActive);
-
-/* ---------------------------------------------------------------------------
- * Healthcheck e utilitários
- * -------------------------------------------------------------------------*/
-router.get('/healthz', (_req, res) => res.json({ success: true, data: { ok: true } }));
-
-router.get('/csrf', csrfProtection, (req, res) => {
-  const token = req.csrfToken();
-  res.json({ success: true, data: { token } });
-});
-
-// Saúde do DB: retorna driver ativo e versão
-router.get('/health/db', async (_req, res) => {
+/* ======================================================================
+ * Health do banco
+ * ====================================================================*/
+GET('/health/db', async (_req, res) => {
   try {
-    const db = database.db();
-    const driver = database.adapter().name; // 'pg' | 'sqlite'
-
-    let version = 'desconhecida';
-    if (driver === 'pg') {
-      const row = await db.prepare('SELECT version() AS v').get();
-      version = row?.v || version;
-    } else {
-      const row = await db.prepare('SELECT sqlite_version() AS v').get();
-      version = row?.v ? `SQLite ${row.v}` : 'SQLite (versão desconhecida)';
-    }
-
-    return res.json({ success: true, data: { driver, version } });
+    const row = await database.db().one('SELECT version() AS version');
+    return res.json({
+      success: true,
+      data: {
+        driver: database.driver || process.env.DB_DRIVER || 'pg',
+        version: row.version
+      }
+    });
   } catch (err) {
     console.error('[health/db] erro:', err);
     return res.status(500).json({ success: false, error: 'Falha ao consultar saúde do banco' });
   }
 });
 
-if (process.env.NODE_ENV === 'development') {
-  router.get('/whoami', (req, res) => {
-    res.json({ success: true, data: { user: req.session ? req.session.user || null : null } });
-  });
+/* ======================================================================
+ * Estatísticas (dashboard/relatórios) — antes de rotas com :id
+ * ====================================================================*/
+GET('/messages/stats',     statsHandlers.messagesStats);
+GET('/stats/by-status',    statsHandlers.byStatus);
+GET('/stats/by-recipient', statsHandlers.byRecipient);
+GET('/stats/by-month',     statsHandlers.byMonth);
+
+/* ======================================================================
+ * Messages (CRUD)
+ * ====================================================================*/
+GET(
+  '/messages',
+  validateListMessages,
+  handleValidation,
+  messageController.list
+);
+
+GET(
+  '/messages/:id',
+  validateIdParam,
+  handleValidation,
+  messageController.getById
+);
+
+POST(
+  '/messages',
+  csrfProtection,
+  validateCreateMessage,
+  handleValidation,
+  messageController.create
+);
+
+PUT(
+  '/messages/:id',
+  csrfProtection,
+  validateIdParam,
+  validateUpdateMessage,
+  handleValidation,
+  messageController.update
+);
+
+PATCH(
+  '/messages/:id',
+  csrfProtection,
+  validateIdParam,
+  validateUpdateMessage,
+  handleValidation,
+  messageController.update
+);
+
+PATCH(
+  '/messages/:id/status',
+  csrfProtection,
+  validateIdParam,
+  validateUpdateStatus,
+  handleValidation,
+  messageController.updateStatus
+);
+
+DELETE(
+  '/messages/:id',
+  csrfProtection,
+  validateIdParam,
+  handleValidation,
+  messageController.remove
+);
+
+/* ======================================================================
+ * Users (opcional)
+ * ====================================================================*/
+if (userController && typeof userController.me === 'function') {
+  GET('/users/me', userController.me);
 }
 
 module.exports = router;

--- a/views/register.ejs
+++ b/views/register.ejs
@@ -4,32 +4,40 @@
 
   <main class="container mt-5" style="max-width:500px;">
     <h1 class="mb-4">Registrar</h1>
-    <form method="POST" action="/register">
+
+    <form method="POST" action="/register" novalidate>
       <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+
       <div class="mb-3">
         <label for="name" class="form-label">Nome</label>
-        <input type="text" class="form-control" id="name" name="name" value="<%= typeof name !== 'undefined' ? name : '' %>">
+        <input type="text" class="form-control" id="name" name="name"
+               value="<%= typeof name === 'string' ? name : '' %>">
       </div>
+
       <div class="mb-3">
         <label for="email" class="form-label">E-mail</label>
-        <input type="email" class="form-control" id="email" name="email" value="<%= typeof email !== 'undefined' ? email : '' %>">
+        <input type="email" class="form-control" id="email" name="email"
+               value="<%= typeof email === 'string' ? email : '' %>">
       </div>
+
       <div class="mb-3">
         <label for="password" class="form-label">Senha</label>
         <input type="password" class="form-control" id="password" name="password">
       </div>
+
       <div class="mb-3">
         <label for="role" class="form-label">Perfil</label>
-        <select id="role" name="role" class="form-select">
-          <% if (Array.isArray(roles)) { %>
-            <% roles.forEach(r => { %>
-              <option value="<%= r %>" <%= (selectedRole ? selectedRole === r : r === 'OPERADOR') ? 'selected' : '' %>><%= r %></option>
-            <% }) %>
-          <% } %>
+        <select id="role" name="role" class="form-control">
+          <% const r = (typeof role === 'string' ? role : 'OPERADOR'); %>
+          <option value="ADMIN" <%= r === 'ADMIN' ? 'selected' : '' %>>ADMIN</option>
+          <option value="SUPERVISOR" <%= r === 'SUPERVISOR' ? 'selected' : '' %>>SUPERVISOR</option>
+          <option value="OPERADOR" <%= r === 'OPERADOR' ? 'selected' : '' %>>OPERADOR</option>
+          <option value="LEITOR" <%= r === 'LEITOR' ? 'selected' : '' %>>LEITOR</option>
         </select>
       </div>
-      <% if (typeof errors !== 'undefined' && Array.isArray(errors)) { %>
-        <div class="alert alert-danger">
+
+      <% if (Array.isArray(errors) && errors.length) { %>
+        <div class="alert alert-danger" role="alert">
           <ul class="mb-0">
             <% errors.forEach(e => { %>
               <li><%= e.msg %></li>
@@ -37,11 +45,14 @@
           </ul>
         </div>
       <% } %>
-      <% if (typeof error !== 'undefined') { %>
-        <div class="alert alert-danger"><%= error %></div>
+
+      <% if (typeof error === 'string' && error.trim().length > 0) { %>
+        <div class="alert alert-danger" role="alert"><%= error %></div>
       <% } %>
+
       <button type="submit" class="btn btn-primary">Registrar</button>
     </form>
   </main>
 
   <%- include('partials/footer') %>
+


### PR DESCRIPTION
## O que foi feito
- **/api/messages/stats**: contadores `total`, `pending`, `in_progress`, `resolved` (labels pt-BR).
- **/api/stats/by-month**: série 12 meses (rótulos mm/aaaa) com `date_trunc`.
- **/api/stats/by-status** e **/api/stats/by-recipient**: agregações para gráficos.
- **routes/api.js**: wrappers defensivos para evitar `argument handler must be a function` na carga.
- **Dashboard**: “Recados Recentes” (Intl pt-BR, tz America/Sao_Paulo) tolerando `created_at|createdAt`.
- **CORS**: em DEV aceita `null`/`localhost`; produção segue restrita ao allowlist.
- **/register**: removida faixa vermelha; CSRF ok.

## Arquivos tocados
- `controllers/statsController.js` (novo)
- `models/stats.js` (novo)
- `routes/api.js`
- `models/message.js`
- `middleware/cors.js`
- `public/js/{app.js,recados.js,utils.js}`
- `views/register.ejs`

## Testes (smoke)
```bash
curl -s http://127.0.0.1:3000/api/messages/stats       | jq .
curl -s http://127.0.0.1:3000/api/stats/by-status      | jq .
curl -s http://127.0.0.1:3000/api/stats/by-recipient   | jq .
curl -s http://127.0.0.1:3000/api/stats/by-month       | jq .
