### PR TITLE
feat(admin): Setores (CRUD) + CORS somente na API

### DIFF
--- a/controllers/sectorController.js
+++ b/controllers/sectorController.js
@@ -1,0 +1,150 @@
+// controllers/sectorController.js
+// Endpoints admin para Setores. Mensagens em pt-BR; chaves JSON em inglês.
+
+const { validationResult, body, param, query } = require('express-validator');
+const Sector = require('../models/sector');
+const UserSector = require('../models/userSector');
+
+// Util: envia 400 com erros de validação em pt-BR
+function sendValidation(res, errors) {
+  return res.status(400).json({ success: false, error: errors.array().map(e => e.msg).join('; ') });
+}
+
+// Validations
+exports.validateList = [
+  query('q').optional().isString().withMessage('Busca inválida'),
+  query('page').optional().isInt({ min: 1 }).withMessage('Página inválida'),
+  query('limit').optional().isInt({ min: 1, max: 200 }).withMessage('Limite inválido'),
+];
+
+exports.validateCreate = [
+  body('name').isString().withMessage('Nome inválido').bail()
+    .trim().notEmpty().withMessage('Nome do setor é obrigatório').bail()
+    .isLength({ max: 120 }).withMessage('Nome do setor não pode exceder 120 caracteres'),
+  body('email').optional({ values: 'falsy' }).isEmail().withMessage('E-mail de setor inválido'),
+];
+
+exports.validateUpdate = [
+  param('id').isInt({ min: 1 }).withMessage('ID inválido'),
+  ...exports.validateCreate,
+];
+
+exports.validateToggle = [
+  param('id').isInt({ min: 1 }).withMessage('ID inválido'),
+  body('is_active').isBoolean().withMessage('Valor inválido para ativo'),
+];
+
+exports.validateUserSectors = [
+  param('id').isInt({ min: 1 }).withMessage('ID de usuário inválido'),
+  body('sectorIds').isArray({ min: 1 }).withMessage('Pelo menos um setor deve ser selecionado'),
+  body('sectorIds.*').isInt({ min: 1 }).withMessage('IDs de setor inválidos'),
+];
+
+// Handlers
+exports.list = async (req, res) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) return sendValidation(res, errors);
+
+  const { q, page, limit } = req.query;
+  const result = await Sector.list({ q, page, limit });
+  return res.json({ success: true, data: result });
+};
+
+exports.create = async (req, res) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) return sendValidation(res, errors);
+
+  try {
+    const created = await Sector.create(req.body);
+    return res.status(201).json({ success: true, data: created, message: 'Setor criado com sucesso' });
+  } catch (err) {
+    if (err.code === 'VALIDATION') {
+      return res.status(400).json({ success: false, error: err.message });
+    }
+    if (err.code === 'UNIQUE') {
+      return res.status(409).json({ success: false, error: err.message });
+    }
+    console.error('[sectors/create] erro:', err);
+    return res.status(500).json({ success: false, error: 'Erro ao criar setor' });
+  }
+};
+
+exports.update = async (req, res) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) return sendValidation(res, errors);
+
+  const id = Number(req.params.id);
+  try {
+    const ok = await Sector.update(id, req.body);
+    if (!ok) return res.status(404).json({ success: false, error: 'Setor não encontrado' });
+    const data = await Sector.getById(id);
+    return res.json({ success: true, data, message: 'Setor atualizado com sucesso' });
+  } catch (err) {
+    if (err.code === 'VALIDATION') return res.status(400).json({ success: false, error: err.message });
+    if (err.code === 'UNIQUE') return res.status(409).json({ success: false, error: err.message });
+    console.error('[sectors/update] erro:', err);
+    return res.status(500).json({ success: false, error: 'Erro ao atualizar setor' });
+  }
+};
+
+exports.toggle = async (req, res) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) return sendValidation(res, errors);
+
+  const id = Number(req.params.id);
+  const { is_active } = req.body;
+  try {
+    const ok = await Sector.setActive(id, is_active);
+    if (!ok) return res.status(404).json({ success: false, error: 'Setor não encontrado' });
+    const data = await Sector.getById(id);
+    return res.json({ success: true, data, message: is_active ? 'Setor ativado' : 'Setor desativado' });
+  } catch (err) {
+    console.error('[sectors/toggle] erro:', err);
+    return res.status(500).json({ success: false, error: 'Erro ao alterar status do setor' });
+  }
+};
+
+exports.remove = async (req, res) => {
+  const id = Number(req.params.id);
+  try {
+    const ok = await Sector.remove(id);
+    if (!ok) return res.status(404).json({ success: false, error: 'Setor não encontrado' });
+    return res.json({ success: true, message: 'Setor excluído com sucesso' });
+  } catch (err) {
+    if (err.code === 'SECTOR_HAS_USERS') {
+      return res.status(400).json({ success: false, error: err.message });
+    }
+    console.error('[sectors/remove] erro:', err);
+    return res.status(500).json({ success: false, error: 'Erro ao excluir setor' });
+  }
+};
+
+exports.getUserSectors = async (req, res) => {
+  const userId = Number(req.params.id);
+  try {
+    const data = await UserSector.listUserSectors(userId);
+    return res.json({ success: true, data });
+  } catch (err) {
+    console.error('[users/sectors/get] erro:', err);
+    return res.status(500).json({ success: false, error: 'Erro ao obter setores do usuário' });
+  }
+};
+
+exports.setUserSectors = async (req, res) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) return sendValidation(res, errors);
+
+  const userId = Number(req.params.id);
+  const { sectorIds } = req.body;
+  try {
+    const data = await UserSector.setUserSectors(userId, sectorIds);
+    return res.json({ success: true, data, message: 'Setores do usuário atualizados' });
+  } catch (err) {
+    if (['VALIDATION', 'SECTOR_MIN_ONE', 'USER_MIN_ONE'].includes(err.code)) {
+      return res.status(400).json({ success: false, error: err.message });
+    }
+    console.error('[users/sectors/set] erro:', err);
+    return res.status(500).json({ success: false, error: 'Erro ao atualizar setores do usuário' });
+  }
+};
+

--- a/models/sector.js
+++ b/models/sector.js
@@ -1,0 +1,167 @@
+// models/sector.js
+// Regras de negócio de "Setores" (PG-only).
+// Comentários em pt-BR; identificadores em inglês.
+
+const db = require('../config/database');
+
+// Helper placeholder PG
+const ph = (i) => `$${i}`;
+
+// Normalizações
+const toStr = (v) => (v === undefined || v === null ? '' : String(v));
+const trim = (v) => toStr(v).trim();
+const emptyToNull = (v) => (trim(v) === '' ? null : trim(v));
+const normalizeEmail = (email) => trim(email).toLowerCase();
+
+const SELECT_COLUMNS = `
+  id, name, email, is_active, created_at, updated_at
+`;
+
+function mapRow(row) {
+  if (!row) return null;
+  return {
+    id: row.id,
+    name: row.name,
+    email: row.email,
+    is_active: row.is_active === true || row.is_active === 't' || row.is_active === 1,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}
+
+async function getById(id) {
+  const { rows } = await db.query(`SELECT ${SELECT_COLUMNS} FROM sectors WHERE id = ${ph(1)} LIMIT 1`, [id]);
+  return mapRow(rows?.[0]);
+}
+
+async function list({ q = '', page = 1, limit = 10 } = {}) {
+  const l = Math.max(1, Math.min(Number(limit) || 10, 200));
+  const p = Math.max(1, Number(page) || 1);
+  const offset = (p - 1) * l;
+
+  const filters = [];
+  const params = [];
+  let i = 1;
+
+  const query = trim(q);
+  if (query) {
+    filters.push(`(LOWER(name) LIKE ${ph(i)} OR LOWER(email) LIKE ${ph(i + 1)})`);
+    const term = `%${query.toLowerCase()}%`;
+    params.push(term, term);
+    i += 2;
+  }
+
+  const where = filters.length ? `WHERE ${filters.join(' AND ')}` : '';
+
+  const { rows } = await db.query(`
+    SELECT ${SELECT_COLUMNS}
+      FROM sectors
+      ${where}
+  ORDER BY name ASC
+     LIMIT ${ph(i)} OFFSET ${ph(i + 1)}
+  `, [...params, l, offset]);
+
+  const { rows: cRows } = await db.query(`SELECT COUNT(*)::int AS total FROM sectors ${where}`, params);
+  const total = Number(cRows?.[0]?.total || 0);
+
+  return {
+    data: rows.map(mapRow),
+    pagination: { total, page: p, limit: l, pages: Math.max(1, Math.ceil(total / l)) },
+  };
+}
+
+async function create({ name, email }) {
+  const n = trim(name);
+  if (!n) {
+    const e = new Error('Nome do setor é obrigatório');
+    e.code = 'VALIDATION';
+    throw e;
+  }
+  if (n.length > 120) {
+    const e = new Error('Nome do setor não pode exceder 120 caracteres');
+    e.code = 'VALIDATION';
+    throw e;
+  }
+  const em = emptyToNull(email) ? normalizeEmail(email) : null;
+
+  try {
+    const { rows } = await db.query(`
+      INSERT INTO sectors (name, email, is_active)
+      VALUES (${ph(1)}, ${ph(2)}, TRUE)
+      RETURNING ${SELECT_COLUMNS}
+    `, [n, em]);
+    return mapRow(rows?.[0]);
+  } catch (err) {
+    if (err.code === '23505') {
+      // unique violation (LOWER(name) unique ou LOWER(email) unique)
+      const e = new Error(em && /email/i.test(err.detail || '') ? 'E-mail de setor já cadastrado' : 'Nome de setor já cadastrado');
+      e.code = 'UNIQUE';
+      throw e;
+    }
+    throw err;
+  }
+}
+
+async function update(id, { name, email }) {
+  const n = trim(name);
+  if (!n) {
+    const e = new Error('Nome do setor é obrigatório');
+    e.code = 'VALIDATION';
+    throw e;
+  }
+  if (n.length > 120) {
+    const e = new Error('Nome do setor não pode exceder 120 caracteres');
+    e.code = 'VALIDATION';
+    throw e;
+  }
+  const em = emptyToNull(email) ? normalizeEmail(email) : null;
+
+  try {
+    const { rowCount } = await db.query(`
+      UPDATE sectors
+         SET name = ${ph(1)},
+             email = ${ph(2)},
+             updated_at = CURRENT_TIMESTAMP
+       WHERE id = ${ph(3)}
+    `, [n, em, id]);
+    return rowCount > 0;
+  } catch (err) {
+    if (err.code === '23505') {
+      const e = new Error(em && /email/i.test(err.detail || '') ? 'E-mail de setor já cadastrado' : 'Nome de setor já cadastrado');
+      e.code = 'UNIQUE';
+      throw e;
+    }
+    throw err;
+  }
+}
+
+async function canDelete(id) {
+  const { rows } = await db.query(`SELECT EXISTS(SELECT 1 FROM user_sectors WHERE sector_id=${ph(1)}) AS has_users`, [id]);
+  return !Boolean(rows?.[0]?.has_users);
+}
+
+async function remove(id) {
+  // Regra: não pode excluir setor que ainda tem usuários
+  const ok = await canDelete(id);
+  if (!ok) {
+    const e = new Error('Não é possível excluir setor com usuários associados');
+    e.code = 'SECTOR_HAS_USERS';
+    throw e;
+  }
+  const { rowCount } = await db.query(`DELETE FROM sectors WHERE id = ${ph(1)}`, [id]);
+  return rowCount > 0;
+}
+
+async function setActive(id, isActive) {
+  const { rowCount } = await db.query(`
+    UPDATE sectors
+       SET is_active = ${ph(1)}, updated_at = CURRENT_TIMESTAMP
+     WHERE id = ${ph(2)}
+  `, [!!isActive, id]);
+  return rowCount > 0;
+}
+
+module.exports = {
+  getById, list, create, update, remove, setActive,
+};
+

--- a/models/userSector.js
+++ b/models/userSector.js
@@ -1,0 +1,104 @@
+// models/userSector.js
+// Associação N:N entre users e sectors, com garantias de "mínimo 1" em ambos os lados.
+// Comentários em pt-BR; identificadores em inglês.
+
+const db = require('../config/database');
+
+const ph = (i) => `$${i}`;
+
+async function listUserSectors(userId) {
+  const { rows } = await db.query(`
+    SELECT us.user_id, s.id AS sector_id, s.name, s.email, s.is_active
+      FROM user_sectors us
+      JOIN sectors s ON s.id = us.sector_id
+     WHERE us.user_id = ${ph(1)}
+  `, [userId]);
+  return rows.map(r => ({
+    user_id: r.user_id,
+    sector: { id: r.sector_id, name: r.name, email: r.email, is_active: r.is_active === true || r.is_active === 't' }
+  }));
+}
+
+// Define exatamente os setores de um usuário (substituição completa).
+// Regra: lista não pode ser vazia; não pode deixar qualquer setor sem usuários após a operação.
+async function setUserSectors(userId, sectorIds) {
+  if (!Array.isArray(sectorIds) || sectorIds.length === 0) {
+    const e = new Error('Pelo menos um setor deve ser selecionado');
+    e.code = 'VALIDATION';
+    throw e;
+  }
+  const uniqueIds = [...new Set(sectorIds.map(Number).filter(Number.isFinite))];
+  if (uniqueIds.length === 0) {
+    const e = new Error('IDs de setor inválidos');
+    e.code = 'VALIDATION';
+    throw e;
+  }
+
+  const client = await db.connect();
+  try {
+    await client.query('BEGIN DEFERRABLE');
+
+    // Setores atuais
+    const { rows: cur } = await client.query(`
+      SELECT sector_id FROM user_sectors WHERE user_id = ${ph(1)}
+    `, [userId]);
+    const current = cur.map(r => r.sector_id);
+
+    const toAdd = uniqueIds.filter(id => !current.includes(id));
+    const toRemove = current.filter(id => !uniqueIds.includes(id));
+
+    // Garantia: após remover, nenhum setor fica vazio
+    if (toRemove.length > 0) {
+      const { rows } = await client.query(`
+        SELECT sector_id, COUNT(*)::int AS cnt
+          FROM user_sectors
+         WHERE sector_id = ANY(${ph(1)})
+         GROUP BY sector_id
+      `, [toRemove]);
+      const counts = Object.fromEntries(rows.map(r => [r.sector_id, r.cnt]));
+      const emptyWouldOccur = toRemove.some(id => (counts[id] || 0) <= 1);
+      if (emptyWouldOccur) {
+        const e = new Error('Não é possível remover: algum setor ficaria sem usuários');
+        e.code = 'SECTOR_MIN_ONE';
+        throw e;
+      }
+    }
+
+    // Aplica remoções
+    if (toRemove.length > 0) {
+      await client.query(`
+        DELETE FROM user_sectors WHERE user_id = ${ph(1)} AND sector_id = ANY(${ph(2)})
+      `, [userId, toRemove]);
+    }
+
+    // Aplica adições (ignora duplicatas)
+    for (const sid of toAdd) {
+      await client.query(`
+        INSERT INTO user_sectors (user_id, sector_id)
+        VALUES (${ph(1)}, ${ph(2)})
+        ON CONFLICT DO NOTHING
+      `, [userId, sid]);
+    }
+
+    // Garantia: usuário não pode ficar sem setor
+    const { rows: after } = await client.query(`
+      SELECT COUNT(*)::int AS total FROM user_sectors WHERE user_id = ${ph(1)}
+    `, [userId]);
+    if (Number(after?.[0]?.total || 0) < 1) {
+      const e = new Error('Usuário deve pertencer a pelo menos um setor');
+      e.code = 'USER_MIN_ONE';
+      throw e;
+    }
+
+    await client.query('COMMIT');
+    return listUserSectors(userId);
+  } catch (err) {
+    try { await client.query('ROLLBACK'); } catch {}
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+module.exports = { listUserSectors, setUserSectors };
+

--- a/public/js/admin-sectors.js
+++ b/public/js/admin-sectors.js
@@ -1,0 +1,179 @@
+// public/js/admin-sectors.js
+
+document.addEventListener('DOMContentLoaded', () => {
+  // A partir daqui o Bootstrap já deve estar presente
+  // (caso não esteja, exibe aviso e aborta para evitar erro no console)
+  if (!window.bootstrap) {
+    console.warn('[admin-sectors] Bootstrap não encontrado. Verifique a ordem de scripts no footer.');
+    return;
+  }
+
+  (function () {
+    const $ = (s) => document.querySelector(s);
+    const $$ = (s) => Array.from(document.querySelectorAll(s));
+
+    const tbody = $('#sectorsTableBody');
+    const pag = $('#pagination');
+    const searchForm = $('#searchForm');
+    const qInput = $('#q');
+    const btnNew = $('#btnNewSector');
+
+    // Modal
+    const modalEl = $('#sectorModal');
+    const modal = new bootstrap.Modal(modalEl);
+    const form = $('#sectorForm');
+    const idInput = $('#sectorId');
+    const nameInput = $('#sectorName');
+    const emailInput = $('#sectorEmail');
+
+    let state = { page: 1, limit: 10, q: '' };
+
+    function toastOk(msg) { (window.Toast?.success || alert)(msg); }
+    function toastErr(msg) { (window.Toast?.error || alert)(msg); }
+
+    async function api(url, options = {}) {
+      const res = await fetch(url, {
+        method: options.method || 'GET',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'same-origin', // envia cookie de sessão
+        body: options.body ? JSON.stringify(options.body) : undefined,
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!json.success) throw new Error(json.error || 'Falha na operação');
+      return json;
+    }
+
+    async function load() {
+      tbody.innerHTML = `<tr><td colspan="4">Carregando...</td></tr>`;
+      try {
+        const { data } = await api(`/api/sectors?q=${encodeURIComponent(state.q)}&page=${state.page}&limit=${state.limit}`);
+        renderTable(data.data);
+        renderPagination(data.pagination);
+      } catch (err) {
+        tbody.innerHTML = `<tr><td colspan="4">${err.message}</td></tr>`;
+      }
+    }
+
+    function renderTable(items) {
+      if (!items || items.length === 0) {
+        tbody.innerHTML = `<tr><td colspan="4">Nenhum setor encontrado.</td></tr>`;
+        return;
+      }
+      tbody.innerHTML = items.map(s => `
+        <tr data-id="${s.id}">
+          <td>${escapeHtml(s.name)}</td>
+          <td>${s.email ? escapeHtml(s.email) : '<span class="text-muted">—</span>'}</td>
+          <td>${s.is_active ? '<span class="badge bg-success">Ativo</span>' : '<span class="badge bg-secondary">Inativo</span>'}</td>
+          <td class="text-nowrap">
+            <button class="btn btn-sm btn-outline-primary me-1" data-action="edit">Editar</button>
+            <button class="btn btn-sm btn-outline-${s.is_active ? 'warning' : 'success'} me-1" data-action="toggle">
+              ${s.is_active ? 'Desativar' : 'Ativar'}
+            </button>
+            <button class="btn btn-sm btn-outline-danger" data-action="delete">Excluir</button>
+          </td>
+        </tr>
+      `).join('');
+    }
+
+    function renderPagination(p) {
+      pag.innerHTML = '';
+      if (!p || p.pages <= 1) return;
+      const mk = (page, label, active = false) => `
+        <li class="page-item ${active ? 'active' : ''}">
+          <a class="page-link" href="#" data-page="${page}">${label}</a>
+        </li>`;
+      const items = [];
+      for (let i = 1; i <= p.pages; i++) items.push(mk(i, i, i === p.page));
+      pag.innerHTML = items.join('');
+    }
+
+    function escapeHtml(s) {
+      return String(s).replace(/[&<>"']/g, (m) => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[m]));
+    }
+
+    pag.addEventListener('click', (e) => {
+      const a = e.target.closest('a[data-page]');
+      if (!a) return;
+      e.preventDefault();
+      state.page = Number(a.dataset.page);
+      load();
+    });
+
+    searchForm.addEventListener('submit', (e) => {
+      e.preventDefault();
+      state.q = qInput.value.trim();
+      state.page = 1;
+      load();
+    });
+
+    btnNew.addEventListener('click', () => {
+      idInput.value = '';
+      nameInput.value = '';
+      emailInput.value = '';
+      $('#sectorModalLabel').textContent = 'Novo setor';
+      modal.show();
+    });
+
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const payload = { name: nameInput.value.trim(), email: emailInput.value.trim() || undefined };
+      try {
+        if (idInput.value) {
+          await api(`/api/sectors/${idInput.value}`, { method: 'PUT', body: payload });
+          toastOk('Setor atualizado com sucesso');
+        } else {
+          await api('/api/sectors', { method: 'POST', body: payload });
+          toastOk('Setor criado com sucesso');
+        }
+        modal.hide();
+        load();
+      } catch (err) {
+        toastErr(err.message);
+      }
+    });
+
+    document.querySelector('#sectorsTableBody').addEventListener('click', async (e) => {
+      const btn = e.target.closest('button[data-action]');
+      if (!btn) return;
+      const tr = btn.closest('tr');
+      const id = tr?.dataset?.id;
+      if (!id) return;
+
+      const action = btn.dataset.action;
+      if (action === 'edit') {
+        const tds = tr.querySelectorAll('td');
+        idInput.value = id;
+        nameInput.value = tds[0].textContent.trim();
+        emailInput.value = tds[1].textContent.includes('—') ? '' : tds[1].textContent.trim();
+        $('#sectorModalLabel').textContent = 'Editar setor';
+        modal.show();
+        return;
+      }
+      if (action === 'toggle') {
+        const active = btn.textContent.includes('Desativar');
+        try {
+          await api(`/api/sectors/${id}/toggle`, { method: 'PUT', body: { is_active: !active } });
+          toastOk(!active ? 'Setor ativado' : 'Setor desativado');
+          load();
+        } catch (err) {
+          toastErr(err.message);
+        }
+        return;
+      }
+      if (action === 'delete') {
+        if (!confirm('Tem certeza que deseja excluir este setor?')) return;
+        try {
+          await api(`/api/sectors/${id}`, { method: 'DELETE' });
+          toastOk('Setor excluído com sucesso');
+          load();
+        } catch (err) {
+          toastErr(err.message);
+        }
+      }
+    });
+
+    // init
+    load();
+  })();
+});
+

--- a/routes/api.js
+++ b/routes/api.js
@@ -4,7 +4,7 @@
 const Router = require('router');
 const router = Router();
 
-// Controllers
+// Controllers existentes
 const messageController = require('../controllers/messageController');
 const statsController   = require('../controllers/statsController');
 
@@ -18,63 +18,17 @@ const {
   validateQueryMessages
 } = require('../middleware/validation');
 
-// Painel ADMIN de Usuarios
+// Painel ADMIN de Usuários
 const { requireRole } = require('../middleware/auth');
 const UserController = require('../controllers/userController');
 const {
   validateUserCreate,
   validateUserUpdate,
   validateIdParam
-} = require('../middleware/validation'); // <- não redeclara handleValidationErrors
+} = require('../middleware/validation'); // não redeclarar handleValidationErrors
 
-// Admin - Users (somente ADMIN)
-router.get('/users',
-  requireRole('ADMIN'),
-  UserController.list
-);
-
-router.get('/users/:id',
-  requireRole('ADMIN'),
-  validateIdParam,
-  handleValidationErrors,
-  UserController.getById
-);
-
-router.post('/users',
-  requireRole('ADMIN'),
-  validateUserCreate,
-  handleValidationErrors,
-  UserController.create
-);
-
-router.put('/users/:id',
-  requireRole('ADMIN'),
-  validateIdParam,
-  validateUserUpdate,
-  handleValidationErrors,
-  UserController.update
-);
-
-router.patch('/users/:id/active',
-  requireRole('ADMIN'),
-  validateIdParam,
-  handleValidationErrors,
-  UserController.setActive
-);
-
-router.patch('/users/:id/password',
-  requireRole('ADMIN'),
-  validateIdParam,
-  handleValidationErrors,
-  UserController.resetPassword
-);
-
-router.delete('/users/:id',
-  requireRole('ADMIN'),
-  validateIdParam,
-  handleValidationErrors,
-  UserController.remove
-);
+// --------- Admin: Setores ---------
+const sectorController = require('../controllers/sectorController');
 
 // --- Helper defensivo para middlewares vindos de fontes diversas ---
 function flatFns(...mws) {
@@ -129,46 +83,38 @@ function flatFns(...mws) {
 }
 
 // ========== Messages ==========
-
-// Listar (com querystring: limit/offset/status/recipient/start_date/end_date)
 router.get(
   '/messages',
   ...flatFns(validateQueryMessages, handleValidationErrors),
   messageController.list
 );
 
-// KPIs de cards (total/pending/in_progress/resolved)
 router.get('/messages/stats', ...flatFns(statsController.messagesStats));
 
-// Obter 1
 router.get(
   '/messages/:id',
   ...flatFns(validateId, handleValidationErrors),
   messageController.getById
 );
 
-// Criar
 router.post(
   '/messages',
   ...flatFns(validateCreateMessage, handleValidationErrors),
   messageController.create
 );
 
-// Atualizar
 router.put(
   '/messages/:id',
   ...flatFns(validateId, validateUpdateMessage, handleValidationErrors),
   messageController.update
 );
 
-// Atualizar status
 router.patch(
   '/messages/:id/status',
   ...flatFns(validateId, validateUpdateStatus, handleValidationErrors),
   messageController.updateStatus
 );
 
-// Remover
 router.delete(
   '/messages/:id',
   ...flatFns(validateId, handleValidationErrors),
@@ -179,6 +125,97 @@ router.delete(
 router.get('/stats/by-status',    ...flatFns(statsController.byStatus));
 router.get('/stats/by-recipient', ...flatFns(statsController.byRecipient));
 router.get('/stats/by-month',     ...flatFns(statsController.byMonth));
+
+// ========== Admin - Users ==========
+router.get('/users',
+  requireRole('ADMIN'),
+  UserController.list
+);
+
+router.get('/users/:id',
+  requireRole('ADMIN'),
+  validateIdParam,
+  handleValidationErrors,
+  UserController.getById
+);
+
+router.post('/users',
+  requireRole('ADMIN'),
+  validateUserCreate,
+  handleValidationErrors,
+  UserController.create
+);
+
+router.put('/users/:id',
+  requireRole('ADMIN'),
+  validateIdParam,
+  validateUserUpdate,
+  handleValidationErrors,
+  UserController.update
+);
+
+router.patch('/users/:id/active',
+  requireRole('ADMIN'),
+  validateIdParam,
+  handleValidationErrors,
+  UserController.setActive
+);
+
+router.patch('/users/:id/password',
+  requireRole('ADMIN'),
+  validateIdParam,
+  handleValidationErrors,
+  UserController.resetPassword
+);
+
+router.delete('/users/:id',
+  requireRole('ADMIN'),
+  validateIdParam,
+  handleValidationErrors,
+  UserController.remove
+);
+
+// ========== Admin - Sectors ==========
+router.get('/sectors',
+  requireRole('ADMIN'),
+  ...flatFns(sectorController.validateList),
+  sectorController.list
+);
+
+router.post('/sectors',
+  requireRole('ADMIN'),
+  ...flatFns(sectorController.validateCreate),
+  sectorController.create
+);
+
+router.put('/sectors/:id',
+  requireRole('ADMIN'),
+  ...flatFns(sectorController.validateUpdate),
+  sectorController.update
+);
+
+router.put('/sectors/:id/toggle',
+  requireRole('ADMIN'),
+  ...flatFns(sectorController.validateToggle),
+  sectorController.toggle
+);
+
+router.delete('/sectors/:id',
+  requireRole('ADMIN'),
+  sectorController.remove
+);
+
+// ========== Admin - User ↔ Sectors ==========
+router.get('/users/:id/sectors',
+  requireRole('ADMIN'),
+  sectorController.getUserSectors
+);
+
+router.put('/users/:id/sectors',
+  requireRole('ADMIN'),
+  ...flatFns(sectorController.validateUserSectors),
+  sectorController.setUserSectors
+);
 
 // Export
 module.exports = router;

--- a/routes/web.js
+++ b/routes/web.js
@@ -11,13 +11,26 @@ const MessageModel = require('../models/message'); // para /recados/:id
 
 const router = express.Router();
 
+// ------------------------------ Admin --------------------------------------
 // Admin → Usuários (apenas ADMIN)
 router.get('/admin/users', requireAuth, requireRole('ADMIN'), (req, res) => {
   const csrfToken = typeof req.csrfToken === 'function' ? req.csrfToken() : undefined;
   return res.render('admin-users', {
     title: 'Admin · Usuários',
     csrfToken,
-    scripts: ['/js/admin-users.js'], // novo JS do painel admin
+    user: req.session.user || null,
+    scripts: ['/js/admin-users.js'], // JS do painel admin de usuários
+  });
+});
+
+// Admin → Setores (apenas ADMIN)
+router.get('/admin/sectors', requireAuth, requireRole('ADMIN'), (req, res) => {
+  const csrfToken = typeof req.csrfToken === 'function' ? req.csrfToken() : undefined;
+  return res.render('admin-sectors', {
+    title: 'Admin · Setores',
+    csrfToken,
+    user: req.session.user || null,
+    scripts: ['/js/admin-sectors.js'], // JS do painel admin de setores
   });
 });
 

--- a/server.js
+++ b/server.js
@@ -39,13 +39,8 @@ app.locals.cssFile = isProd ? '/css/style.min.css' : '/css/style.css';
 app.set('view engine', 'ejs');
 app.set('views', path.join(__dirname, 'views'));
 
-// CORS e OPTIONS
-app.use(corsMw);
-app.options(/.*/, corsMw, (req, res) => {
-  res.setHeader('Access-Control-Allow-Methods', corsMw.ALLOWED_METHODS);
-  res.setHeader('Access-Control-Allow-Headers', corsMw.ALLOWED_HEADERS);
-  res.sendStatus(204);
-});
+// CORS somente na API (opcional recomendado; evita mexer no fluxo Web)
+app.use('/api', corsMw);
 
 if (isProd && validateOrigin) app.use(validateOrigin);
 
@@ -250,8 +245,8 @@ app.get('/health', healthController.check);
 // Rotas
 app.use('/login', loginLimiter);
 app.use('/api', apiLimiter);
-app.use('/api', apiRoutes);
-app.use('/', webRoutes);
+app.use('/api', apiRoutes); // ✅ API primeiro (antes das rotas Web)
+app.use('/', webRoutes);    // Web por último (tem 404 próprio)
 
 // Erros genéricos
 app.use((err, req, res, _next) => {

--- a/views/admin-sectors.ejs
+++ b/views/admin-sectors.ejs
@@ -1,0 +1,99 @@
+<%- include('partials/header') %>
+<body>
+  <%- include('partials/navbar') %>
+
+  <main class="main" role="main">
+    <div class="container">
+
+      <!-- Cabeçalho da página (alinhado com Admin · Usuários) -->
+      <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 2rem;">
+        <div>
+          <h1 style="font-size: 2rem; font-weight: 700; margin-bottom: 0.5rem;"><%= title %></h1>
+          <p style="color: var(--text-secondary);">Gerencie os setores do sistema</p>
+        </div>
+        <button id="btnNewSector" class="btn btn-primary btn-lg">
+          <span aria-hidden="true">➕</span> Novo setor
+        </button>
+      </div>
+
+      <!-- Card: Pesquisar -->
+      <section class="card" style="margin-bottom: 1.5rem;">
+        <div class="card-body">
+          <h2 class="card-title h5">Pesquisar</h2>
+          <p class="card-subtitle text-muted" style="margin-bottom: 1rem;">Busque por nome ou e-mail</p>
+
+          <form id="searchForm" class="row g-2">
+            <div class="col-sm-6">
+              <input type="text" class="form-control" id="q" placeholder="Pesquisar por nome ou e-mail">
+            </div>
+            <div class="col-auto">
+              <button class="btn btn-outline-secondary" type="submit">Buscar</button>
+            </div>
+          </form>
+        </div>
+      </section>
+
+      <!-- Card: Setores (lista) -->
+      <section class="card">
+        <div class="card-body">
+          <h2 class="card-title h5">Setores</h2>
+          <p class="card-subtitle text-muted" style="margin-bottom: 1rem;">Lista de setores cadastrados</p>
+
+          <div class="table-responsive">
+            <table class="table table-striped align-middle">
+              <thead>
+                <tr>
+                  <th>Nome</th>
+                  <th>E-mail</th>
+                  <th>Status</th>
+                  <th style="width: 220px;">Ações</th>
+                </tr>
+              </thead>
+              <tbody id="sectorsTableBody">
+                <tr><td colspan="4">Carregando...</td></tr>
+              </tbody>
+            </table>
+          </div>
+
+          <nav>
+            <ul class="pagination" id="pagination"></ul>
+          </nav>
+        </div>
+      </section>
+
+      <!-- Modal: criar/editar setor (IDs esperados pelo JS) -->
+      <div class="modal fade" id="sectorModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog">
+          <form class="modal-content" id="sectorForm">
+            <div class="modal-header">
+              <h5 class="modal-title" id="sectorModalLabel">Novo setor</h5>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+            </div>
+            <div class="modal-body">
+              <input type="hidden" id="sectorId">
+
+              <div class="mb-3">
+                <label for="sectorName" class="form-label">Nome</label>
+                <input type="text" class="form-control" id="sectorName" maxlength="120" required>
+                <div class="form-text">Obrigatório. Máx. 120 caracteres.</div>
+              </div>
+
+              <div class="mb-3">
+                <label for="sectorEmail" class="form-label">E-mail do setor (opcional)</label>
+                <input type="email" class="form-control" id="sectorEmail" placeholder="ex.: atendimento@exemplo.com">
+                <div class="form-text">Usado para notificações ao setor inteiro.</div>
+              </div>
+            </div>
+            <div class="modal-footer">
+              <button class="btn btn-secondary" data-bs-dismiss="modal" type="button">Cancelar</button>
+              <button class="btn btn-primary" type="submit">Salvar</button>
+            </div>
+          </form>
+        </div>
+      </div>
+
+    </div>
+  </main>
+
+  <%- include('partials/footer') %>
+

--- a/views/partials/navbar.ejs
+++ b/views/partials/navbar.ejs
@@ -6,6 +6,7 @@
     <button class="navbar-toggler" id="navbarToggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Alternar navegação">
       <span class="navbar-toggler-icon"></span>
     </button>
+
     <div class="collapse navbar-collapse" id="navbarNav">
       <ul class="navbar-nav mx-auto mb-2 mb-lg-0">
         <li class="nav-item">
@@ -22,8 +23,21 @@
           <li class="nav-item">
             <a class="nav-link<%= title === 'Relatórios' ? ' active' : '' %>" href="/relatorios">Relatórios</a>
           </li>
-          <li class="nav-item">
-            <a class="nav-link<%= title === 'Admin · Usuários' ? ' active' : '' %>" href="/admin/users">Usuários</a>
+
+          <!-- Menu Admin (dropdown) -->
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle<%= (title && title.startsWith('Admin ·')) ? ' active' : '' %>"
+               href="#" id="adminDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+              Admin
+            </a>
+            <ul class="dropdown-menu" aria-labelledby="adminDropdown">
+              <li>
+                <a class="dropdown-item<%= title === 'Admin · Usuários' ? ' active' : '' %>" href="/admin/users">Usuários</a>
+              </li>
+              <li>
+                <a class="dropdown-item<%= title === 'Admin · Setores' ? ' active' : '' %>" href="/admin/sectors">Setores</a>
+              </li>
+            </ul>
           </li>
         <% } %>
       </ul>


### PR DESCRIPTION
Inclui tela e API de Setores, CORS restrito à API e ajustes de navbar.

Testes manuais:
- CRUD Setores OK (criar/editar/toggle/excluir)
- CORS: preflight tratado no middleware; remove rota OPTIONS wildcard (Express 5)
- Navbar: menu Admin → Usuários/Setores
